### PR TITLE
feat: 로그인 API 구현

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Config/JwtUtil.java
+++ b/src/main/java/com/pillmate/pillmate/Config/JwtUtil.java
@@ -55,4 +55,9 @@ public class JwtUtil {
             return false;
         }
     }
+    
+    // 토큰 만료 시간 반환 (밀리초)
+    public long getExpirationTimeMillis() {
+        return EXPIRATION_TIME;
+    }
 }

--- a/src/main/java/com/pillmate/pillmate/Config/SecurityConfig.java
+++ b/src/main/java/com/pillmate/pillmate/Config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // JWT 사용으로 세션 비활성화
             .authorizeHttpRequests(authz -> authz
                 .requestMatchers("/api/auth/**").permitAll() // 인증 API 허용 (기존 경로)
-                .requestMatchers("/api/v1/signup", "/api/v1/login").permitAll() // 회원가입, 로그인 API 허용
+                .requestMatchers("/api/v1/signup", "/api/v1/auth/login").permitAll() // 회원가입, 로그인 API 허용
                 .requestMatchers("/api/dose-events/**").permitAll() // DoseEvent API 허용 (개발용)
                 .requestMatchers("/swagger.html", "/swagger-ui/**", "/api-docs/**").permitAll() // Swagger 허용
                 .requestMatchers("/h2-console/**").permitAll() // H2 콘솔 허용 (개발용)

--- a/src/main/java/com/pillmate/pillmate/Controller/AuthController.java
+++ b/src/main/java/com/pillmate/pillmate/Controller/AuthController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.pillmate.pillmate.Config.JwtUtil;
 import com.pillmate.pillmate.DTO.ConsentDto;
 import com.pillmate.pillmate.DTO.LoginRequest;
+import com.pillmate.pillmate.DTO.LoginResponse;
 import com.pillmate.pillmate.DTO.SignUpRequest;
 import com.pillmate.pillmate.DTO.SignUpResponse;
 import com.pillmate.pillmate.Domain.User;
@@ -90,31 +91,35 @@ public class AuthController {
         @ApiResponse(responseCode = "200", description = "로그인 성공"),
         @ApiResponse(responseCode = "401", description = "인증 실패 (잘못된 이메일 또는 비밀번호)")
     })
-    @PostMapping("/login")
-    public ResponseEntity<Map<String, Object>> login(@Valid @RequestBody LoginRequest request) {
-        Map<String, Object> response = new HashMap<>();
-        
+    @PostMapping("/auth/login")
+    public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
         try {
             User user = userService.login(request.getEmail(), request.getPassword());
             
             // JWT 토큰 생성
-            String token = jwtUtil.generateToken(user.getEmail());
+            String accessToken = jwtUtil.generateToken(user.getEmail());
             
-            response.put("success", true);
-            response.put("message", "로그인 성공");
-            response.put("token", token);
-            response.put("user", Map.of(
-                "id", user.getId(),
-                "name", user.getName(),
-                "email", user.getEmail()
-            ));
+            // 사용자 정보
+            LoginResponse.UserInfo userInfo = LoginResponse.UserInfo.builder()
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .build();
+            
+            // Response 생성
+            LoginResponse response = LoginResponse.builder()
+                    .message("로그인 성공")
+                    .accessToken(accessToken)
+                    .tokenType("Bearer")
+                    .expiresInMillis(jwtUtil.getExpirationTimeMillis())
+                    .user(userInfo)
+                    .build();
             
             return ResponseEntity.ok(response);
             
         } catch (IllegalArgumentException e) {
-            response.put("success", false);
-            response.put("message", e.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("message", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
         }
     }
 }

--- a/src/main/java/com/pillmate/pillmate/DTO/LoginResponse.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/LoginResponse.java
@@ -1,0 +1,28 @@
+package com.pillmate.pillmate.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+    private String message;
+    private String accessToken;
+    private String tokenType;
+    private Long expiresInMillis;
+    private UserInfo user;
+    
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserInfo {
+        private String email;
+        private String name;
+    }
+}
+


### PR DESCRIPTION
## 📌 변경 사항

### 로그인 API 구현
- POST `/api/v1/auth/login` 엔드포인트 추가
- LoginResponse DTO 생성 (accessToken, tokenType, expiresInMillis, user)
- JWT 토큰 만료 시간 반환 메서드 추가
- SecurityConfig에 `/api/v1/auth/login` 경로 허용 추가
- Response 형식 명세서에 맞게 변경

## 🔍 상세 내용

### API 스펙
- **URL**: `POST /api/v1/auth/login`
- **Request Body**:
  - `email`: 사용자 이메일 (String, 필수)
  - `password`: 사용자 비밀번호 (String, 필수)

- **Response**: 
  - HTTP 200 OK
  - `message`: "로그인 성공"
  - `accessToken`: JWT 토큰
  - `tokenType`: "Bearer"
  - `expiresInMillis`: 토큰 만료 시간 (밀리초)
  - `user`: 사용자 정보 (email, name)

### 주요 변경사항

1. **엔드포인트 URL 변경**
   - 기존: `/api/v1/login`
   - 변경: `/api/v1/auth/login` (명세서에 맞게 수정)

2. **Response 형식 변경**
   - 기존: `success`, `message`, `token`, `user` (id 포함)
   - 변경: `message`, `accessToken`, `tokenType`, `expiresInMillis`, `user` (email, name만 포함)

3. **JwtUtil 확장**
   - `getExpirationTimeMillis()` 메서드 추가: 토큰 만료 시간 반환
   - 현재 만료 시간: 24시간 (86400000 밀리초)

4. **보안 설정**
   - SecurityConfig에 `/api/v1/auth/login` 경로 허용 추가

### 인증 로직
- 이메일과 비밀번호로 사용자 검증
- 비밀번호 일치 시 JWT 토큰 발급
- 토큰 타입은 Bearer 방식 사용

## ✅ 체크리스트

- [x] 기능이 정상적으로 동작하는지 확인했습니다.
  - Swagger를 통해 API 테스트 완료
  - JWT 토큰 생성 및 반환 확인
  - Response 형식 명세서 준수 확인
  - 에러 처리 (잘못된 이메일/비밀번호) 확인

- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
  - 회원가입 API (`/api/v1/signup`) 유지
  - 기존 로그인 로직 (UserService.login) 유지
  - JWT 토큰 생성 로직 유지

## 👀 리뷰 요청 사항

### 중점적으로 확인이 필요한 부분
1. **Response 형식**: 명세서에 맞는 Response 형식인지 확인
   - `accessToken`, `tokenType`, `expiresInMillis` 필드 포함 여부
   - `user` 객체에 `email`, `name`만 포함되는지 확인

2. **엔드포인트 URL**: `/api/v1/auth/login` 경로가 올바른지 확인

3. **토큰 만료 시간**: 현재 24시간(86400000ms)으로 설정되어 있는데, 명세서 요구사항과 일치하는지 확인

4. **SecurityConfig**: `/api/v1/auth/login` 경로가 정상적으로 허용되는지 확인

5. **에러 응답**: 인증 실패 시 401 Unauthorized와 적절한 에러 메시지 반환 확인

### 추가 확인 사항
- Swagger 문서에서 로그인 API가 올바르게 표시되는지 확인
- JWT 토큰이 올바르게 생성되고 유효한지 확인
- 토큰 타입이 "Bearer"로 반환되는지 확인

## 📎 참고 자료

### 생성된 파일
- `LoginResponse.java`: 로그인 응답 DTO
  - `accessToken`: JWT 토큰
  - `tokenType`: "Bearer"
  - `expiresInMillis`: 토큰 만료 시간
  - `user`: 사용자 정보 (email, name)

### 수정된 파일
- `AuthController.java`: 
  - 로그인 엔드포인트 URL 변경 (`/api/v1/login` → `/api/v1/auth/login`)
  - Response 형식 변경 (LoginResponse DTO 사용)
  - 에러 응답 형식 개선

- `JwtUtil.java`: 
  - `getExpirationTimeMillis()` 메서드 추가

- `SecurityConfig.java`: 
  - `/api/v1/auth/login` 경로 허용 추가

### API 테스트 예시
```json
// Request
POST /api/v1/auth/login
{
  "email": "user@example.com",
  "password": "Abcd1234!"
}

// Response (200 OK)
{
  "message": "로그인 성공",
  "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyQGV4YW1wbGUuY29tIiwiaWF0IjoxNzU0OTg4MjAzLCJleHAiOjE3NTQ5OTE4MDN9...",
  "tokenType": "Bearer",
  "expiresInMillis": 86400000,
  "user": {
    "email": "user@example.com",
    "name": "홍길동"
  }
}

// Error Response (401 Unauthorized)
{
  "message": "비밀번호가 일치하지 않습니다"
}
```

### 명세서 요구사항
- ✅ Access Token 발급
- ✅ Token Type: "Bearer"
- ✅ 만료 시간 반환 (expiresInMillis)
- ✅ 사용자 정보 반환 (email, name)
- ⚠️ Refresh Token: 명세서에 언급되었으나 현재 구현에는 미포함 (추후 구현 예정)