### PR TITLE
feat: 구글 소셜 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client' // OAuth2 클라이언트
 
     // JWT 의존성
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/src/main/java/com/pillmate/pillmate/Config/SecurityConfig.java
+++ b/src/main/java/com/pillmate/pillmate/Config/SecurityConfig.java
@@ -7,22 +7,45 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
+import com.pillmate.pillmate.Security.OAuth2.OAuth2FailureHandler;
+import com.pillmate.pillmate.Security.OAuth2.OAuth2SuccessHandler;
+import com.pillmate.pillmate.Security.OAuth2.OAuth2UserProviderRouter;
+
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    
+    private final OAuth2UserProviderRouter oAuth2UserProviderRouter;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
     
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (API 개발용)
-            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // JWT 사용으로 세션 비활성화
+            // OAuth2 로그인을 위해 세션을 사용하되, OAuth2 인증 후에는 STATELESS로 처리
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                .maximumSessions(1)
+            )
             .authorizeHttpRequests(authz -> authz
                 .requestMatchers("/api/auth/**").permitAll() // 인증 API 허용 (기존 경로)
                 .requestMatchers("/api/v1/signup", "/api/v1/auth/login").permitAll() // 회원가입, 로그인 API 허용
                 .requestMatchers("/api/v1/main/calendar/**").permitAll() // 캘린더 일정 API 허용 (개발용)
+                .requestMatchers("/oauth2/**", "/login/**").permitAll() // OAuth2 소셜 로그인 관련 요청 허용
                 .requestMatchers("/swagger.html", "/swagger-ui/**", "/api-docs/**").permitAll() // Swagger 허용
                 .requestMatchers("/h2-console/**").permitAll() // H2 콘솔 허용 (개발용)
                 .anyRequest().authenticated() // 나머지는 인증 필요
+            )
+            .oauth2Login(oauth2 -> oauth2
+                .userInfoEndpoint(userInfo -> userInfo
+                    .userService(oAuth2UserProviderRouter) // 사용자 정보 받아오기
+                )
+                .successHandler(oAuth2SuccessHandler) // JWT 발급 및 응답
+                .failureHandler(oAuth2FailureHandler) // 오류 처리
             )
             .formLogin(form -> form.disable()) // 기본 로그인 폼 비활성화
             .httpBasic(basic -> basic.disable()); // HTTP Basic 인증 비활성화

--- a/src/main/java/com/pillmate/pillmate/Domain/AuthProvider.java
+++ b/src/main/java/com/pillmate/pillmate/Domain/AuthProvider.java
@@ -1,0 +1,19 @@
+package com.pillmate.pillmate.Domain;
+
+import lombok.Getter;
+
+@Getter
+public enum AuthProvider {
+    LOCAL("일반 가입"),
+    GOOGLE("구글"),
+    KAKAO("카카오"),
+    NAVER("네이버"),
+    APPLE("애플");
+
+    private final String description;
+
+    AuthProvider(String description) {
+        this.description = description;
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Domain/User.java
+++ b/src/main/java/com/pillmate/pillmate/Domain/User.java
@@ -8,6 +8,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -74,6 +76,13 @@ public class User {
     @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean dataUsage;  // 데이터 활용 동의 여부
     
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(20) DEFAULT 'LOCAL'")
+    private AuthProvider provider;  // 인증 제공자 (LOCAL, GOOGLE, KAKAO, NAVER, APPLE)
+    
+    @Column(nullable = false, length = 100, columnDefinition = "VARCHAR(100) DEFAULT 'LOCAL'")
+    private String providerId;  // 제공자별 고유 ID
+    
     @CreatedDate
     @Column(nullable = false, updatable = false, columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
@@ -104,5 +113,19 @@ public class User {
         if (alcohol != null) this.defaultAlcoholAmount = alcohol;
         if (meds != null) this.currentMedications = meds;
         if (beverage != null) this.preferredBeverageType = beverage;
+    }
+    
+    // 소셜 로그인 사용자 생성 메서드
+    public static User createSocialUser(String email, String name, AuthProvider provider, String providerId) {
+        User user = new User();
+        user.email = email;
+        user.password = "oauth2"; // 소셜 로그인은 비밀번호 불필요
+        user.name = name;
+        user.provider = provider;
+        user.providerId = providerId;
+        user.termsOfService = true;  // 소셜 로그인 시 약관 동의로 간주
+        user.privacyPolicy = true;
+        user.dataUsage = false;  // 선택 약관은 false
+        return user;
     }
 }

--- a/src/main/java/com/pillmate/pillmate/Repository/UserRepository.java
+++ b/src/main/java/com/pillmate/pillmate/Repository/UserRepository.java
@@ -15,4 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     
     // 이메일 중복 체크
     boolean existsByEmail(String email);
+    
+    // provider와 providerId로 사용자 찾기
+    Optional<User> findByProviderAndProviderId(com.pillmate.pillmate.Domain.AuthProvider provider, String providerId);
 }

--- a/src/main/java/com/pillmate/pillmate/Security/CustomUserDetails.java
+++ b/src/main/java/com/pillmate/pillmate/Security/CustomUserDetails.java
@@ -1,0 +1,80 @@
+package com.pillmate.pillmate.Security;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.pillmate.pillmate.Domain.User;
+
+import lombok.Getter;
+
+@Getter
+public class CustomUserDetails implements UserDetails, OAuth2User {
+    
+    private final User user;
+    
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+    
+    // UserDetails 구현
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+    
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+    
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+    
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+    
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+    
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+    
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+    
+    // OAuth2User 구현
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Collections.emptyMap();
+    }
+    
+    @Override
+    public String getName() {
+        return user.getEmail();
+    }
+    
+    // 추가 메서드
+    public Long getId() {
+        return user.getId();
+    }
+    
+    public String getEmail() {
+        return user.getEmail();
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Security/OAuth2/GoogleOAuth2UserService.java
+++ b/src/main/java/com/pillmate/pillmate/Security/OAuth2/GoogleOAuth2UserService.java
@@ -1,0 +1,120 @@
+package com.pillmate.pillmate.Security.OAuth2;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pillmate.pillmate.Domain.AuthProvider;
+import com.pillmate.pillmate.Domain.User;
+import com.pillmate.pillmate.Repository.UserRepository;
+import com.pillmate.pillmate.Security.CustomUserDetails;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    
+    private final UserRepository userRepository;
+    
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        try {
+            OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+            OAuth2User oAuth2User = delegate.loadUser(userRequest);
+            
+            // 디버깅: 구글에서 받은 모든 속성 확인
+            Map<String, Object> attributes = oAuth2User.getAttributes();
+            log.info("구글 OAuth2 사용자 속성: {}", attributes);
+            
+            // 구글 사용자 정보 추출
+            String email = oAuth2User.getAttribute("email");
+            String nameAttribute = oAuth2User.getAttribute("name");
+            String providerId = oAuth2User.getAttribute("sub"); // 구글 고유 ID
+            
+            log.info("추출된 정보 - email: {}, name: {}, providerId: {}", email, nameAttribute, providerId);
+            
+            if (email == null || providerId == null) {
+                log.error("필수 정보 누락 - email: {}, providerId: {}", email, providerId);
+                throw new OAuth2AuthenticationException("구글 인증 정보를 가져올 수 없습니다 (email 또는 providerId 누락)");
+            }
+            
+            // name이 null이면 email 사용
+            final String name = (nameAttribute == null || nameAttribute.trim().isEmpty()) 
+                    ? email.split("@")[0] 
+                    : nameAttribute;
+            
+            if (nameAttribute == null || nameAttribute.trim().isEmpty()) {
+                log.info("name이 null이어서 email에서 추출: {}", name);
+            }
+            
+            final AuthProvider provider = AuthProvider.GOOGLE;
+            
+            // 디버깅: 조회 전에 값 확인
+            log.info("사용자 조회 시도 - provider: {}, providerId: {}", provider, providerId);
+            
+            // provider와 providerId로 기존 사용자 확인 (소셜 로그인 사용자)
+            Optional<User> existingUserOpt = userRepository.findByProviderAndProviderId(provider, providerId);
+            log.info("기존 사용자 조회 결과: {}", existingUserOpt.isPresent() ? "찾음" : "없음");
+            
+            if (existingUserOpt.isPresent()) {
+                User existingUser = existingUserOpt.get();
+                log.info("기존 사용자 발견 - id: {}, email: {}, provider: {}, providerId: {}", 
+                        existingUser.getId(), existingUser.getEmail(), 
+                        existingUser.getProvider(), existingUser.getProviderId());
+                return new CustomUserDetails(existingUser);
+            }
+            
+            // 기존 사용자가 없으면 이메일로도 확인 (이미 가입된 구글 사용자인지 체크)
+            Optional<User> existingUserByEmail = userRepository.findByEmail(email);
+            if (existingUserByEmail.isPresent()) {
+                User existingEmailUser = existingUserByEmail.get();
+                log.info("이메일로 기존 사용자 발견 - id: {}, email: {}, provider: {}, providerId: {}", 
+                        existingEmailUser.getId(), existingEmailUser.getEmail(), 
+                        existingEmailUser.getProvider(), existingEmailUser.getProviderId());
+                
+                // 이미 구글 로그인 사용자인 경우
+                if (existingEmailUser.getProvider() == AuthProvider.GOOGLE) {
+                    log.info("구글 사용자로 인식 - providerId 업데이트 가능성 확인");
+                    // providerId가 다른 경우 업데이트 (구글 계정이 변경되었거나 providerId가 바뀐 경우)
+                    if (!existingEmailUser.getProviderId().equals(providerId)) {
+                        log.warn("providerId 불일치 - 기존: {}, 새로운: {}", 
+                                existingEmailUser.getProviderId(), providerId);
+                        // providerId 업데이트는 하지 않고, 기존 사용자 반환
+                    }
+                    return new CustomUserDetails(existingEmailUser);
+                } else {
+                    // 다른 방식으로 가입된 사용자
+                    log.error("이미 다른 방식({})으로 가입된 이메일: {}", existingEmailUser.getProvider(), email);
+                    throw new OAuth2AuthenticationException("이미 다른 방식으로 가입된 이메일입니다");
+                }
+            }
+            
+            // 새 사용자 생성
+            log.info("새 사용자 생성 시작 - email: {}, name: {}", email, name);
+            User newUser = User.createSocialUser(email, name, provider, providerId);
+            User savedUser = userRepository.save(newUser);
+            log.info("새 사용자 생성 완료 - id: {}, email: {}", savedUser.getId(), savedUser.getEmail());
+            return new CustomUserDetails(savedUser);
+        } catch (OAuth2AuthenticationException e) {
+            log.error("OAuth2 인증 오류: {}", e.getMessage(), e);
+            throw e;
+        } catch (Exception e) {
+            log.error("예상치 못한 오류 발생: {}", e.getMessage(), e);
+            OAuth2Error oauth2Error = new OAuth2Error("oauth2_error", "소셜 로그인 처리 중 오류가 발생했습니다: " + e.getMessage(), null);
+            throw new OAuth2AuthenticationException(oauth2Error, e);
+        }
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Security/OAuth2/OAuth2FailureHandler.java
+++ b/src/main/java/com/pillmate/pillmate/Security/OAuth2/OAuth2FailureHandler.java
@@ -1,0 +1,52 @@
+package com.pillmate.pillmate.Security.OAuth2;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+    
+    private final ObjectMapper objectMapper;
+    
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        
+        String errorMessage = exception.getMessage();
+        if (errorMessage == null || errorMessage.isEmpty()) {
+            errorMessage = exception.getClass().getSimpleName();
+        }
+        
+        log.error("OAuth2 로그인 실패: {}", errorMessage, exception);
+        
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("message", "소셜 로그인에 실패했습니다: " + errorMessage);
+        errorResponse.put("error", exception.getClass().getSimpleName());
+        
+        // 원인 파악을 위한 추가 정보
+        if (exception.getCause() != null) {
+            errorResponse.put("cause", exception.getCause().getMessage());
+        }
+        
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Security/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/pillmate/pillmate/Security/OAuth2/OAuth2SuccessHandler.java
@@ -1,0 +1,56 @@
+package com.pillmate.pillmate.Security.OAuth2;
+
+import java.io.IOException;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pillmate.pillmate.Config.JwtUtil;
+import com.pillmate.pillmate.DTO.LoginResponse;
+import com.pillmate.pillmate.Security.CustomUserDetails;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+    
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+    
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        
+        // JWT 토큰 생성
+        String accessToken = jwtUtil.generateToken(userDetails.getEmail());
+        
+        // 사용자 정보
+        LoginResponse.UserInfo userInfo = LoginResponse.UserInfo.builder()
+                .email(userDetails.getEmail())
+                .name(userDetails.getUser().getName())
+                .build();
+        
+        // Response 생성
+        LoginResponse loginResponse = LoginResponse.builder()
+                .message("로그인 성공")
+                .accessToken(accessToken)
+                .tokenType("Bearer")
+                .expiresInMillis(jwtUtil.getExpirationTimeMillis())
+                .user(userInfo)
+                .build();
+        
+        // 응답
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(loginResponse));
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Security/OAuth2/OAuth2UserProviderRouter.java
+++ b/src/main/java/com/pillmate/pillmate/Security/OAuth2/OAuth2UserProviderRouter.java
@@ -1,0 +1,30 @@
+package com.pillmate.pillmate.Security.OAuth2;
+
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class OAuth2UserProviderRouter implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    
+    private final GoogleOAuth2UserService googleOAuth2UserService;
+    // 추후 NaverOAuth2UserService, KakaoOAuth2UserService 등 추가 가능
+    
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        String provider = userRequest.getClientRegistration().getRegistrationId(); // "google"
+        
+        return switch (provider) {
+            case "google" -> googleOAuth2UserService.loadUser(userRequest);
+            // case "naver" -> naverOAuth2UserService.loadUser(userRequest);
+            // case "kakao" -> kakaoOAuth2UserService.loadUser(userRequest);
+            default -> throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다: " + provider);
+        };
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Service/UserService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/UserService.java
@@ -8,6 +8,7 @@ import com.pillmate.pillmate.DTO.BasicProfileResponse;
 import com.pillmate.pillmate.DTO.BasicProfileUpdateRequest;
 import com.pillmate.pillmate.DTO.UserProfileResponse;
 import com.pillmate.pillmate.DTO.UserProfileUpdateRequest;
+import com.pillmate.pillmate.Domain.AuthProvider;
 import com.pillmate.pillmate.Domain.User;
 import com.pillmate.pillmate.Repository.UserRepository;
 import com.pillmate.pillmate.Util.PasswordValidator;
@@ -64,6 +65,8 @@ public class UserService {
                 .termsOfService(request.getConsent().getTermsOfService())
                 .privacyPolicy(request.getConsent().getPrivacyPolicy())
                 .dataUsage(dataUsage)
+                .provider(AuthProvider.LOCAL)  // 일반 회원가입
+                .providerId("LOCAL")  // 일반 회원가입 구분용
                 .build();
         
         // 비밀번호 암호화

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,25 @@ spring:
     properties:
       hibernate.format_sql: true
 
+  # OAuth2 설정
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID:YOUR_GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET:YOUR_GOOGLE_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - profile
+              - email
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
+
 # 로깅 레벨 설정: SQL을 더 자세히 보고 싶을 때 사용
 logging:
   level:


### PR DESCRIPTION
## 📌 변경 사항

- 구글 소셜 로그인 API 구현
- OAuth2 클라이언트 의존성 추가
- AuthProvider enum 생성 (LOCAL, GOOGLE, KAKAO, NAVER, APPLE)
- User 엔티티에 provider, providerId 필드 추가
- CustomUserDetails 클래스 생성 (UserDetails, OAuth2User 구현)
- GoogleOAuth2UserService 구현 (구글 사용자 정보 처리)
- OAuth2UserProviderRouter 구현 (Provider별 라우팅)
- OAuth2SuccessHandler 구현 (JWT 토큰 발급)
- OAuth2FailureHandler 구현 (오류 처리)
- SecurityConfig에 OAuth2 로그인 설정 추가
- application.yml에 구글 OAuth2 설정 추가
- UserRepository에 findByProviderAndProviderId 메서드 추가
- 일반 회원가입 계정과 소셜 로그인 계정 분리 (연동 안 함)

## 🔍 상세 내용

### 주요 구현 사항

1. **OAuth2 클라이언트 설정**
   - `spring-boot-starter-oauth2-client` 의존성 추가
   - `application.yml`에 구글 OAuth2 설정 추가 (환경 변수 사용)

2. **인증 제공자 관리**
   - `AuthProvider` enum으로 인증 제공자 구분 (LOCAL, GOOGLE, KAKAO, NAVER, APPLE)
   - User 엔티티에 `provider`와 `providerId` 필드 추가

3. **소셜 로그인 플로우**
   - 구글 로그인 URL: `http://localhost:8080/oauth2/authorization/google`
   - 리다이렉션 URL: `http://localhost:8080/login/oauth2/code/google`
   - 로그인 성공 시 JWT 토큰 발급 (일반 로그인과 동일한 형식)

4. **계정 관리 정책**
   - 일반 회원가입 계정과 소셜 로그인 계정은 분리 관리
   - 같은 이메일로 다른 방식 가입 시 연동하지 않음 (보안 고려)

5. **오류 처리**
   - OAuth2FailureHandler로 소셜 로그인 실패 시 상세 오류 정보 제공
   - 로깅을 통한 디버깅 지원

### 핵심 로직

- `GoogleOAuth2UserService`: 구글에서 받은 사용자 정보를 처리하고, 기존 사용자 확인 또는 신규 사용자 생성
- `OAuth2UserProviderRouter`: 향후 다른 소셜 로그인 제공자(네이버, 카카오 등) 추가 시 확장 가능한 구조
- `CustomUserDetails`: Spring Security의 UserDetails와 OAuth2User를 모두 구현하여 일반 로그인과 소셜 로그인 모두 지원

## ✅ 체크리스트

- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 시크릿 정보가 커밋되지 않았는지 확인했습니다.
- [x] 일반 로그인 API가 정상 작동하는지 확인했습니다.

## 👀 리뷰 요청 사항

- 구글 OAuth2 클라이언트 ID와 Secret은 환경 변수로 설정해야 합니다 (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`)
- 구글 클라이언트 설정에서 리다이렉션 URI가 등록되어 있는지 확인 필요
- 일반 회원가입 계정과 소셜 로그인 계정 분리 정책이 적절한지 검토 필요
- 향후 네이버, 카카오 소셜 로그인 추가 시 확장성 검토

## 📎 참고 자료 (선택)

- 구글 소셜 로그인 테스트: `http://localhost:8080/oauth2/authorization/google`
- 일반 로그인 API는 기존과 동일하게 작동합니다 (`POST /api/v1/auth/login`)
- 일반 회원가입 API는 기존과 동일하게 작동합니다 (`POST /api/v1/signup`)