### PR TITLE
[BE-#26] 복약 일정 수정 API 구현

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Controller/ScheduleController.java
+++ b/src/main/java/com/pillmate/pillmate/Controller/ScheduleController.java
@@ -4,7 +4,9 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.pillmate.pillmate.DTO.ScheduleRequest;
 import com.pillmate.pillmate.DTO.ScheduleResponse;
+import com.pillmate.pillmate.DTO.ScheduleUpdateRequest;
+import com.pillmate.pillmate.DTO.ScheduleUpdateResponse;
 import com.pillmate.pillmate.Service.ScheduleService;
 
 import java.time.LocalDate;
@@ -157,6 +161,35 @@ public class ScheduleController {
         public static class ScheduleListData {
             private List<ScheduleResponse> schedules;
         }
+    }
+    
+    @Operation(summary = "복약 일정 수정", description = "기존 일정의 세부 정보를 수정합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "일정 수정 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @ApiResponse(responseCode = "404", description = "일정을 찾을 수 없음")
+    })
+    @PutMapping("/schedules/{scheduleId}")
+    public ResponseEntity<ScheduleUpdateResponseWrapper> updateSchedule(
+            @PathVariable Long scheduleId,
+            @Valid @RequestBody ScheduleUpdateRequest request) {
+        ScheduleUpdateResponse updateResponse = scheduleService.updateSchedule(scheduleId, request);
+        
+        ScheduleUpdateResponseWrapper response = ScheduleUpdateResponseWrapper.builder()
+                .message("복약 일정이 수정되었습니다.")
+                .data(updateResponse)
+                .build();
+        
+        return ResponseEntity.ok(response);
+    }
+    
+    @lombok.Getter
+    @lombok.Builder
+    @lombok.NoArgsConstructor
+    @lombok.AllArgsConstructor
+    public static class ScheduleUpdateResponseWrapper {
+        private String message;
+        private ScheduleUpdateResponse data;
     }
 }
 

--- a/src/main/java/com/pillmate/pillmate/DTO/ScheduleUpdateRequest.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ScheduleUpdateRequest.java
@@ -1,0 +1,54 @@
+package com.pillmate.pillmate.DTO;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.pillmate.pillmate.Domain.ScheduleStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "복약 일정 수정 요청")
+public class ScheduleUpdateRequest {
+    
+    @Schema(description = "변경할 알림 시각 (ISO8601 형식)", example = "2025-10-08T09:00:00")
+    private LocalDateTime alarmAt;
+    
+    @Schema(description = "변경할 복용량 또는 용법", example = "1정")
+    private String dose;
+    
+    @Schema(description = "변경할 사용자 메모", example = "시간 조정")
+    private String memo;
+    
+    @Schema(description = "변경할 상태", example = "TAKEN", allowableValues = {"SCHEDULED", "TAKEN", "MISSED", "CANCELLED"})
+    private ScheduleStatus status;
+    
+    @Valid
+    @Schema(description = "알림 설정 변경")
+    private AlarmSettings alarm;
+    
+    @Schema(description = "복용 시작일", example = "2025-10-08")
+    private LocalDate startDate;
+    
+    @Schema(description = "복용 종료일", example = "2025-10-15")
+    private LocalDate endDate;
+    
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "알림 설정")
+    public static class AlarmSettings {
+        @Schema(description = "알림 활성화 여부", example = "true")
+        private Boolean enabled;
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/DTO/ScheduleUpdateResponse.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ScheduleUpdateResponse.java
@@ -1,0 +1,41 @@
+package com.pillmate.pillmate.DTO;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "복약 일정 수정 응답 데이터")
+public class ScheduleUpdateResponse {
+    
+    @Schema(description = "일정 ID", example = "101")
+    private Long scheduleId;
+    
+    @Schema(description = "변경된 필드 리스트", example = "[\"status\", \"alarmAt\"]")
+    private List<String> updatedFields;
+    
+    @Schema(description = "현재 상태", example = "TAKEN")
+    private String status;
+    
+    @Schema(description = "변경된 알림 시각", example = "2025-10-08T09:00:00")
+    private LocalDateTime alarmAt;
+    
+    @Schema(description = "변경된 메모", example = "시간 조정")
+    private String memo;
+    
+    @Schema(description = "복용 시작일", example = "2025-10-08")
+    private LocalDate startDate;
+    
+    @Schema(description = "복용 종료일", example = "2025-10-15")
+    private LocalDate endDate;
+}
+

--- a/src/main/java/com/pillmate/pillmate/Domain/Schedule.java
+++ b/src/main/java/com/pillmate/pillmate/Domain/Schedule.java
@@ -69,5 +69,34 @@ public class Schedule {
     @LastModifiedDate
     @Column(nullable = false)
     private LocalDateTime updatedAt;
+    
+    // 일정 수정을 위한 메서드들
+    public void updateAlarmAt(LocalDateTime alarmAt) {
+        this.alarmAt = alarmAt;
+    }
+    
+    public void updateDose(String dose) {
+        this.dose = dose;
+    }
+    
+    public void updateMemo(String memo) {
+        this.memo = memo;
+    }
+    
+    public void updateStatus(ScheduleStatus status) {
+        this.status = status;
+    }
+    
+    public void updateAlarmEnabled(Boolean alarmEnabled) {
+        this.alarmEnabled = alarmEnabled;
+    }
+    
+    public void updateStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+    
+    public void updateEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
 }
 

--- a/src/main/java/com/pillmate/pillmate/Domain/ScheduleStatus.java
+++ b/src/main/java/com/pillmate/pillmate/Domain/ScheduleStatus.java
@@ -2,7 +2,7 @@ package com.pillmate.pillmate.Domain;
 
 public enum ScheduleStatus {
     SCHEDULED,  // 예정됨
-    COMPLETED,  // 완료됨
+    TAKEN,      // 복용 완료
     MISSED,     // 미복용
     CANCELLED   // 취소됨
 }

--- a/src/main/java/com/pillmate/pillmate/Repository/ScheduleRepository.java
+++ b/src/main/java/com/pillmate/pillmate/Repository/ScheduleRepository.java
@@ -16,14 +16,12 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     
     // 같은 약물과 같은 알림 시각에 존재하는 일정 조회 (완전 중복 체크용)
     @Query("SELECT s FROM Schedule s WHERE s.drugId = :drugId " +
-           "AND s.alarmAt = :alarmAt " +
-           "AND s.status != 'CANCELLED'")
+           "AND s.alarmAt = :alarmAt")
     List<Schedule> findByDrugIdAndAlarmAt(@Param("drugId") Long drugId, 
                                            @Param("alarmAt") LocalDateTime alarmAt);
     
     // 특정 기간에 약물이 이미 등록되어 있는지 확인 (약물 충돌 체크용)
     @Query("SELECT s FROM Schedule s WHERE s.drugId = :drugId " +
-           "AND s.status != 'CANCELLED' " +
            "AND ((s.startDate <= :endDate AND s.endDate >= :startDate))")
     List<Schedule> findOverlappingSchedules(@Param("drugId") Long drugId, 
                                              @Param("startDate") LocalDate startDate,
@@ -35,7 +33,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
                                     @Param("endDate") LocalDate endDate);
     
     // 특정 날짜의 일정 조회 (해당 날짜가 startDate와 endDate 사이에 있는 일정)
-    @Query("SELECT s FROM Schedule s WHERE s.startDate <= :date AND s.endDate >= :date AND s.status != 'CANCELLED' ORDER BY s.alarmAt")
+    @Query("SELECT s FROM Schedule s WHERE s.startDate <= :date AND s.endDate >= :date ORDER BY s.alarmAt")
     List<Schedule> findByDate(@Param("date") LocalDate date);
 }
 

--- a/src/main/java/com/pillmate/pillmate/Service/ScheduleService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/ScheduleService.java
@@ -9,6 +9,8 @@ import com.pillmate.pillmate.Domain.Schedule;
 import com.pillmate.pillmate.Domain.ScheduleStatus;
 import com.pillmate.pillmate.DTO.ScheduleRequest;
 import com.pillmate.pillmate.DTO.ScheduleResponse;
+import com.pillmate.pillmate.DTO.ScheduleUpdateRequest;
+import com.pillmate.pillmate.DTO.ScheduleUpdateResponse;
 import com.pillmate.pillmate.Repository.ScheduleRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -89,6 +91,97 @@ public class ScheduleService {
         return schedules.stream()
                 .map(ScheduleResponse::from)
                 .collect(Collectors.toList());
+    }
+    
+    /**
+     * 일정 수정
+     * @param scheduleId 일정 ID
+     * @param request 수정 요청 데이터
+     * @return 수정된 일정 정보와 변경된 필드 리스트
+     */
+    @Transactional
+    public ScheduleUpdateResponse updateSchedule(Long scheduleId, ScheduleUpdateRequest request) {
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다"));
+        
+        java.util.List<String> updatedFields = new java.util.ArrayList<>();
+        
+        // 복용 기간 검증 및 수정
+        if (request.getStartDate() != null || request.getEndDate() != null) {
+            LocalDate newStartDate = request.getStartDate() != null ? request.getStartDate() : schedule.getStartDate();
+            LocalDate newEndDate = request.getEndDate() != null ? request.getEndDate() : schedule.getEndDate();
+            
+            if (newStartDate.isAfter(newEndDate)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "복용 시작일은 종료일보다 이전이어야 합니다");
+            }
+            
+            if (request.getStartDate() != null && !request.getStartDate().equals(schedule.getStartDate())) {
+                schedule.updateStartDate(request.getStartDate());
+                updatedFields.add("startDate");
+            }
+            
+            if (request.getEndDate() != null && !request.getEndDate().equals(schedule.getEndDate())) {
+                schedule.updateEndDate(request.getEndDate());
+                updatedFields.add("endDate");
+            }
+        }
+        
+        // 알림 시각 수정
+        if (request.getAlarmAt() != null && !request.getAlarmAt().equals(schedule.getAlarmAt())) {
+            LocalDate alarmDate = request.getAlarmAt().toLocalDate();
+            LocalDate currentStartDate = request.getStartDate() != null ? request.getStartDate() : schedule.getStartDate();
+            LocalDate currentEndDate = request.getEndDate() != null ? request.getEndDate() : schedule.getEndDate();
+            
+            if (alarmDate.isBefore(currentStartDate) || alarmDate.isAfter(currentEndDate)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "알림 시각은 복용 기간 내에 있어야 합니다");
+            }
+            schedule.updateAlarmAt(request.getAlarmAt());
+            updatedFields.add("alarmAt");
+        }
+        
+        // 복용량 수정
+        if (request.getDose() != null && !request.getDose().equals(schedule.getDose())) {
+            schedule.updateDose(request.getDose());
+            updatedFields.add("dose");
+        }
+        
+        // 메모 수정
+        if (request.getMemo() != null && !java.util.Objects.equals(request.getMemo(), schedule.getMemo())) {
+            schedule.updateMemo(request.getMemo());
+            updatedFields.add("memo");
+        }
+        
+        // 상태 수정
+        if (request.getStatus() != null && !request.getStatus().equals(schedule.getStatus())) {
+            // CANCELLED 상태에서는 TAKEN이나 MISSED로 변경 불가
+            if (schedule.getStatus() == ScheduleStatus.CANCELLED && 
+                (request.getStatus() == ScheduleStatus.TAKEN || request.getStatus() == ScheduleStatus.MISSED)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "취소된 일정은 복용 완료나 미복용 상태로 변경할 수 없습니다");
+            }
+            schedule.updateStatus(request.getStatus());
+            updatedFields.add("status");
+        }
+        
+        // 알림 설정 수정
+        if (request.getAlarm() != null && request.getAlarm().getEnabled() != null) {
+            boolean newAlarmEnabled = request.getAlarm().getEnabled();
+            if (newAlarmEnabled != schedule.getAlarmEnabled()) {
+                schedule.updateAlarmEnabled(newAlarmEnabled);
+                updatedFields.add("alarm");
+            }
+        }
+        
+        Schedule savedSchedule = scheduleRepository.save(schedule);
+        
+        return ScheduleUpdateResponse.builder()
+                .scheduleId(savedSchedule.getScheduleId())
+                .updatedFields(updatedFields)
+                .status(savedSchedule.getStatus().name())
+                .alarmAt(savedSchedule.getAlarmAt())
+                .memo(savedSchedule.getMemo())
+                .startDate(savedSchedule.getStartDate())
+                .endDate(savedSchedule.getEndDate())
+                .build();
     }
 }
 


### PR DESCRIPTION
## 📌 변경 사항

- PUT `/api/v1/main/calendar/schedules/{scheduleId}` 일정 수정 API 구현
- 일정 부분 업데이트 지원 (알림 시각, 복용량, 메모, 상태, 알림 설정, 복용 기간)
- 변경된 필드 추적 기능 추가
- ScheduleStatus enum 정리 (SCHEDULED, TAKEN, MISSED, CANCELLED)
- CANCELLED 상태에서 TAKEN/MISSED로 변경 불가 검증 추가
- CANCELLED 상태도 조회 가능하도록 Repository 쿼리 수정

## 🔍 상세 내용

### 1. 일정 수정 API
- 엔드포인트: `PUT /api/v1/main/calendar/schedules/{scheduleId}`
- 요청 본문의 모든 필드는 선택적(optional)
- 수정된 필드만 업데이트하고, 변경된 필드 리스트를 응답에 포함

### 2. 상태 변경 로직
- 기본 상태: `SCHEDULED` (일정 등록 시)
- 상태 종류: `SCHEDULED`, `TAKEN`, `MISSED`, `CANCELLED`
- 제약사항: `CANCELLED` 상태에서는 `TAKEN` 또는 `MISSED`로 변경 불가
  - `CANCELLED` → `SCHEDULED` → `TAKEN`/`MISSED` 순서로 변경 필요

### 3. CANCELLED 상태 처리
- `CANCELLED`는 단순 상태 표시 (삭제와 구분)
- `CANCELLED` 상태도 일반 조회에 포함됨
- Repository 쿼리에서 `status != 'CANCELLED'` 필터 제거

### 4. 유효성 검증
- 복용 기간 검증: 시작일은 종료일보다 이전이어야 함
- 알림 시각 검증: 알림 시각은 복용 기간 내에 있어야 함
- 상태 변경 검증: `CANCELLED` → `TAKEN`/`MISSED` 변경 시 에러 반환

### 5. 주요 변경 파일
- `ScheduleController.java`: PUT 엔드포인트 추가
- `ScheduleService.java`: `updateSchedule` 메서드 및 검증 로직 추가
- `ScheduleUpdateRequest.java`: 수정 요청 DTO (신규)
- `ScheduleUpdateResponse.java`: 수정 응답 DTO (신규)
- `Schedule.java`: 엔티티 수정 메서드 추가
- `ScheduleStatus.java`: 상태 enum 정리
- `ScheduleRepository.java`: CANCELLED 필터 제거

## ✅ 체크리스트

- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] Swagger 문서화가 정상적으로 반영되었는지 확인했습니다.
- [x] 상태 변경 검증 로직이 정상적으로 동작하는지 확인했습니다.
- [x] CANCELLED 상태도 조회 가능한지 확인했습니다.

## 👀 리뷰 요청 사항

1. **상태 변경 로직**
   - `CANCELLED` → `TAKEN`/`MISSED` 변경 불가 검증 로직 확인
   - 상태 전환 규칙 검토

2. **부분 업데이트 로직**
   - `updateSchedule` 메서드의 부분 업데이트 처리 방식 확인
   - 변경된 필드 추적 로직 검토

3. **유효성 검증**
   - 복용 기간 및 알림 시각 검증 로직 확인
   - 상태 변경 시 검증 로직 검토

## 📎 참고 자료 (선택)

### API 명세
- 엔드포인트: `PUT /api/v1/main/calendar/schedules/{scheduleId}`
- 요청 본문: `ScheduleUpdateRequest` (모든 필드 optional)
- 응답: `ScheduleUpdateResponse` (변경된 필드 리스트 포함)

### 상태 전환 규칙
- SCHEDULED → TAKEN ✅
- SCHEDULED → MISSED ✅
- SCHEDULED → CANCELLED ✅
- CANCELLED → SCHEDULED ✅
- CANCELLED → TAKEN ❌ (에러 발생)
- CANCELLED → MISSED ❌ (에러 발생)