### PR TITLE
[BE-#30] 복약 단일 일정 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Controller/ScheduleController.java
+++ b/src/main/java/com/pillmate/pillmate/Controller/ScheduleController.java
@@ -147,6 +147,27 @@ public class ScheduleController {
         return ResponseEntity.ok(response);
     }
     
+    @Operation(summary = "복약 일정 단일 조회", description = "일정 ID를 통해 특정 복약 일정의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "일정 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 게시물입니다", 
+                     content = @io.swagger.v3.oas.annotations.media.Content(
+                         mediaType = "application/json",
+                         schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = com.pillmate.pillmate.DTO.ErrorResponse.class)
+                     ))
+    })
+    @GetMapping("/schedules/{scheduleId}")
+    public ResponseEntity<ScheduleDetailResponse> getScheduleById(@PathVariable Long scheduleId) {
+        ScheduleResponse scheduleResponse = scheduleService.getScheduleById(scheduleId);
+        
+        ScheduleDetailResponse response = ScheduleDetailResponse.builder()
+                .message("일정 조회 성공")
+                .data(scheduleResponse)
+                .build();
+        
+        return ResponseEntity.ok(response);
+    }
+    
     @lombok.Getter
     @lombok.Builder
     @lombok.NoArgsConstructor
@@ -201,6 +222,15 @@ public class ScheduleController {
                 .build();
         
         return ResponseEntity.ok(response);
+    }
+    
+    @lombok.Getter
+    @lombok.Builder
+    @lombok.NoArgsConstructor
+    @lombok.AllArgsConstructor
+    public static class ScheduleDetailResponse {
+        private String message;
+        private ScheduleResponse data;
     }
     
     @lombok.Getter

--- a/src/main/java/com/pillmate/pillmate/DTO/ErrorResponse.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ErrorResponse.java
@@ -1,0 +1,25 @@
+package com.pillmate.pillmate.DTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "에러 응답")
+public class ErrorResponse {
+    
+    @Schema(description = "에러 메시지", example = "존재하지 않는 게시물입니다")
+    private String message;
+    
+    @Schema(description = "에러 타입", example = "NOT_FOUND")
+    private String error;
+    
+    @Schema(description = "HTTP 상태 코드", example = "404")
+    private int status;
+}
+

--- a/src/main/java/com/pillmate/pillmate/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pillmate/pillmate/Exception/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.pillmate.pillmate.Exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.pillmate.pillmate.DTO.ErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponse> handleResponseStatusException(ResponseStatusException ex) {
+        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
+        
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .message(ex.getReason() != null ? ex.getReason() : ex.getMessage())
+                .error(status.name())
+                .status(status.value())
+                .build();
+        
+        return ResponseEntity.status(status).body(errorResponse);
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Service/ScheduleService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/ScheduleService.java
@@ -65,6 +65,18 @@ public class ScheduleService {
     }
     
     /**
+     * ID로 단일 일정 조회
+     * @param scheduleId 일정 ID
+     * @return 일정 정보
+     */
+    public ScheduleResponse getScheduleById(Long scheduleId) {
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 게시물입니다"));
+        
+        return ScheduleResponse.from(schedule);
+    }
+    
+    /**
      * 특정 날짜의 일정 조회
      * @param date 조회할 날짜 (YYYY-MM-DD 형식)
      * @return 해당 날짜의 일정 목록


### PR DESCRIPTION
## 📌 변경 사항

- GET `/api/v1/main/calendar/schedules/{scheduleId}` 일정 단일 조회 API 구현
- 일정 ID로 특정 일정의 상세 정보 조회 기능 추가
- 전역 예외 핸들러 및 ErrorResponse DTO 추가
- Swagger에서 에러 메시지 표시 지원

## 🔍 상세 내용

### 1. 일정 단일 조회 API
- 엔드포인트: `GET /api/v1/main/calendar/schedules/{scheduleId}`
- 상세 정보 버튼 클릭 시 사용되는 API
- 날짜 기반 목록 조회와 달리 단일 일정 객체 반환

### 2. 전역 예외 처리
- `GlobalExceptionHandler` 추가로 `ResponseStatusException` 통합 처리
- 일관된 에러 응답 형식 (`ErrorResponse`) 제공
- Swagger에서 에러 메시지 및 응답 형식 표시

### 3. 에러 메시지
- 존재하지 않는 일정 조회 시: "존재하지 않는 게시물입니다" (404 에러)
- 일관된 에러 응답 형식:
  ```json
  {
    "message": "존재하지 않는 게시물입니다",
    "error": "NOT_FOUND",
    "status": 404
  }
  ```

### 4. 주요 변경 파일
- `ScheduleController.java`: GET 엔드포인트 추가, `ScheduleDetailResponse` 내부 클래스 추가
- `ScheduleService.java`: `getScheduleById` 메서드 추가
- `ErrorResponse.java`: 에러 응답 DTO (신규)
- `GlobalExceptionHandler.java`: 전역 예외 핸들러 (신규)

## ✅ 체크리스트

- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] Swagger 문서화가 정상적으로 반영되었는지 확인했습니다.
- [x] 에러 응답이 정상적으로 표시되는지 확인했습니다.

## 👀 리뷰 요청 사항

1. **에러 응답 형식**
   - 전역 예외 핸들러의 에러 응답 형식이 일관성 있는지 확인
   - 다른 API의 에러 응답과 형식이 통일되어 있는지 검토

2. **Swagger 문서화**
   - 에러 응답이 Swagger에 정상적으로 표시되는지 확인
   - ErrorResponse DTO가 Swagger 문서에 제대로 반영되었는지 확인

3. **API 설계**
   - 단일 객체 반환 vs 배열 반환 방식 검토
   - 날짜 기반 조회와 ID 기반 조회의 일관성 확인

## 📎 참고 자료 (선택)

### API 명세
- 엔드포인트: `GET /api/v1/main/calendar/schedules/{scheduleId}`
- 응답: 단일 `ScheduleResponse` 객체
- 에러: 존재하지 않는 일정 ID 시 404 + "존재하지 않는 게시물입니다"

### 사용 사례
- **단일 일정 조회**: 상세 정보 버튼 클릭 → 단일 객체 반환
- **날짜 기반 조회**: 달력에서 전체 일정 확인 → 배열 반환

### 주요 변경사항
- 전역 예외 핸들러 추가로 모든 API에서 일관된 에러 응답 형식 제공
- Swagger에서 에러 메시지 및 응답 형식 표시 지원