### PR TITLE
[BE-#71] 식약처 의약품 제품 허가 정보 API 연동

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Config/MfdsApiProperties.java
+++ b/src/main/java/com/pillmate/pillmate/Config/MfdsApiProperties.java
@@ -1,0 +1,25 @@
+package com.pillmate.pillmate.Config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "external.mfds")
+public class MfdsApiProperties {
+    /**
+     * 기본 API URL (예: https://apis.data.go.kr/1471000)
+     */
+    private String baseUrl;
+
+    /**
+     * 식약처 OpenAPI 서비스 키.
+     * 반드시 운영 환경에서 환경 변수 MFDS_SERVICE_KEY 로 주입하세요.
+     */
+    private String serviceKey;
+}
+

--- a/src/main/java/com/pillmate/pillmate/Config/RestClientConfig.java
+++ b/src/main/java/com/pillmate/pillmate/Config/RestClientConfig.java
@@ -1,0 +1,16 @@
+package com.pillmate.pillmate.Config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Controller/DrugController.java
+++ b/src/main/java/com/pillmate/pillmate/Controller/DrugController.java
@@ -10,6 +10,7 @@ import com.pillmate.pillmate.Service.DrugDetailService;
 import com.pillmate.pillmate.Service.BookmarkService;
 import com.pillmate.pillmate.DTO.ImageResponse;
 import com.pillmate.pillmate.Service.DrugService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -54,6 +55,7 @@ public class DrugController {
     // ---- (상세) 북마크된 약물 기본 정보 조회 ----
     // GET /api/v1/drug/details/{drugId}
     @GetMapping("/details/{drugId}")
+    @Operation(summary = "약품 상세 조회", description = "식약처 품목기준코드로 상세 정보를 조회합니다.")
     public ResponseEntity<DrugDetailResponse> info(@PathVariable String drugId) {
         return ResponseEntity.ok(drugDetailService.fetchDrugDetail(drugId));
     }

--- a/src/main/java/com/pillmate/pillmate/DTO/DrugDetailResponse.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/DrugDetailResponse.java
@@ -1,0 +1,28 @@
+package com.pillmate.pillmate.DTO;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DrugDetailResponse {
+    private final String drugId;
+    private final String name;
+    private final String entpName;
+    private final String rxType;
+    private final String strength;
+    private final List<String> ingredients;
+    private final String efficacy;
+    private final String dosage;
+    private final String cautions;
+    private final Map<String, String> cautionsSummary;
+    private final List<String> images;
+    private final OffsetDateTime retrievedAt;
+}
+

--- a/src/main/java/com/pillmate/pillmate/Service/DrugDetailService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/DrugDetailService.java
@@ -1,0 +1,219 @@
+package com.pillmate.pillmate.Service;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.pillmate.pillmate.DTO.DrugDetailResponse;
+import com.pillmate.pillmate.Service.dto.MfdsEasyDrugResponse.MfdsEasyDrugItem;
+import com.pillmate.pillmate.Service.dto.MfdsIngredientResponse;
+import com.pillmate.pillmate.Service.dto.MfdsPermissionResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DrugDetailService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter BASIC_DATE = DateTimeFormatter.ofPattern("yyyyMMdd", Locale.KOREA);
+
+    private final MfdsDrugInfoClient mfdsDrugInfoClient;
+    private final MfdsDrugIngredientClient mfdsDrugIngredientClient;
+    private final MfdsDrugPermissionClient mfdsDrugPermissionClient;
+
+    public DrugDetailResponse fetchDrugDetail(String drugId) {
+        MfdsEasyDrugItem item = mfdsDrugInfoClient.fetchEasyDrug(drugId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "해당 품목기준코드의 의약품 정보를 찾을 수 없습니다."
+                ));
+
+        List<MfdsIngredientResponse.Item> ingredientItems = mfdsDrugIngredientClient.fetchIngredients(drugId);
+        String strength = resolveStrength(ingredientItems);
+        List<String> ingredients = ingredientItems.stream()
+                .map(MfdsIngredientResponse.Item::getIngredientName)
+                .filter(StringUtils::hasText)
+                .distinct()
+                .collect(Collectors.toList());
+
+        Optional<MfdsPermissionResponse.PermissionItem> permissionOpt = mfdsDrugPermissionClient.fetchPermission(drugId);
+        String resolvedRxType = firstNonBlank(
+                item.getEtcOtcName(),
+                permissionOpt.map(MfdsPermissionResponse.PermissionItem::getResolvedSpcltyPblc).orElse(null),
+                permissionOpt.map(MfdsPermissionResponse.PermissionItem::getResolvedEtcOtcCode).orElse(null)
+        );
+
+        String cautions = joinSections(
+                item.getAtpnWarnQesitm(),
+                item.getAtpnQesitm(),
+                item.getIntrcQesitm(),
+                item.getSeQesitm(),
+                item.getDepositMethodQesitm()
+        );
+
+        Map<String, String> summary = buildCautionSummary(cautions);
+
+        return DrugDetailResponse.builder()
+                .drugId(item.getItemSeq())
+                .name(item.getItemName())
+                .entpName(item.getEntpName())
+                .rxType(withFallback(resolvedRxType, "공식 데이터 미제공"))
+                .strength(withFallback(strength, "공식 데이터 미제공"))
+                .ingredients(ingredients.isEmpty() ? List.of("공식 데이터 미제공") : ingredients)
+                .efficacy(clean(item.getEfcyQesitm()))
+                .dosage(clean(item.getUseMethodQesitm()))
+                .cautions(clean(cautions))
+                .cautionsSummary(summary)
+                .images(extractImages(item.getItemImage()))
+                .retrievedAt(resolveRetrievedAt(item).orElse(OffsetDateTime.now(KST)))
+                .build();
+    }
+
+    private String resolveStrength(List<MfdsIngredientResponse.Item> items) {
+        if (items == null || items.isEmpty()) {
+            return null;
+        }
+
+        List<String> mainStrengths = items.stream()
+                .filter(it -> "Y".equalsIgnoreCase(it.getMainIngredient()))
+                .map(this::formatStrength)
+                .filter(StringUtils::hasText)
+                .distinct()
+                .collect(Collectors.toList());
+
+        List<String> targets = mainStrengths.isEmpty()
+                ? items.stream()
+                        .map(this::formatStrength)
+                        .filter(StringUtils::hasText)
+                        .distinct()
+                        .collect(Collectors.toList())
+                : mainStrengths;
+
+        if (targets.isEmpty()) {
+            return null;
+        }
+        return String.join(", ", targets);
+    }
+
+    private String formatStrength(MfdsIngredientResponse.Item item) {
+        String name = item.getIngredientName();
+        String content = item.getContent();
+        String unit = item.getUnit();
+
+        StringBuilder builder = new StringBuilder();
+        if (StringUtils.hasText(name)) {
+            builder.append(name.trim());
+        }
+        if (StringUtils.hasText(content)) {
+            if (builder.length() > 0) {
+                builder.append(" ");
+            }
+            builder.append(content.trim());
+        }
+        if (StringUtils.hasText(unit)) {
+            if (builder.length() > 0) {
+                builder.append(unit.startsWith(" ") ? "" : " ");
+            }
+            builder.append(unit.trim());
+        }
+        return builder.length() == 0 ? null : builder.toString();
+    }
+
+    private String firstNonBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value != null && !value.trim().isEmpty()) {
+                return value.trim();
+            }
+        }
+        return null;
+    }
+
+    private String withFallback(String value, String fallback) {
+        return StringUtils.hasText(value) ? value : fallback;
+    }
+
+    private String joinSections(String... sections) {
+        StringBuilder builder = new StringBuilder();
+        for (String section : sections) {
+            if (StringUtils.hasText(section)) {
+                if (builder.length() > 0) {
+                    builder.append("\n\n");
+                }
+                builder.append(section.trim());
+            }
+        }
+        return builder.length() == 0 ? null : builder.toString();
+    }
+
+    private Map<String, String> buildCautionSummary(String cautions) {
+        Map<String, String> summary = new LinkedHashMap<>();
+        if (!StringUtils.hasText(cautions)) {
+            return summary;
+        }
+
+        String lower = cautions.toLowerCase(Locale.KOREAN);
+        if (lower.contains("음주") || lower.contains("알코올")) {
+            summary.put("alcohol", "복용 전후 음주를 피하십시오.");
+        }
+        if (lower.contains("카페인")) {
+            summary.put("caffeine", "카페인 함유 제품과 병용 시 주의하세요.");
+        }
+        return summary;
+    }
+
+    private List<String> extractImages(String itemImage) {
+        if (!StringUtils.hasText(itemImage)) {
+            return List.of();
+        }
+        return List.of(itemImage.trim());
+    }
+
+    private Optional<OffsetDateTime> resolveRetrievedAt(MfdsEasyDrugItem item) {
+        String updateDe = item.getUpdateDe();
+        if (StringUtils.hasText(updateDe)) {
+            return parseDate(updateDe);
+        }
+        String openDe = item.getOpenDe();
+        if (StringUtils.hasText(openDe)) {
+            return parseDate(openDe);
+        }
+        return Optional.empty();
+    }
+
+    private Optional<OffsetDateTime> parseDate(String value) {
+        try {
+            LocalDate date = LocalDate.parse(value.trim(), BASIC_DATE);
+            return Optional.of(date.atStartOfDay(KST).toOffsetDateTime());
+        } catch (Exception ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private String clean(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return null;
+        }
+        return raw
+                .replaceAll("(?i)<br\\s*/?>", "\n")
+                .replaceAll("(?i)&nbsp;", " ")
+                .replaceAll("<[^>]+>", "")
+                .trim();
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Service/MfdsDrugInfoClient.java
+++ b/src/main/java/com/pillmate/pillmate/Service/MfdsDrugInfoClient.java
@@ -1,0 +1,75 @@
+package com.pillmate.pillmate.Service;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.pillmate.pillmate.Config.MfdsApiProperties;
+import com.pillmate.pillmate.Service.dto.MfdsEasyDrugResponse;
+import com.pillmate.pillmate.Service.dto.MfdsEasyDrugResponse.MfdsEasyDrugBody;
+import com.pillmate.pillmate.Service.dto.MfdsEasyDrugResponse.MfdsEasyDrugItem;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MfdsDrugInfoClient {
+
+    private static final String EASY_DRUG_PATH = "/DrbEasyDrugInfoService/getDrbEasyDrugList";
+
+    private final RestTemplate restTemplate;
+    private final MfdsApiProperties properties;
+
+    public Optional<MfdsEasyDrugItem> fetchEasyDrug(String itemSeq) {
+        if (!StringUtils.hasText(itemSeq)) {
+            return Optional.empty();
+        }
+
+        URI uri = UriComponentsBuilder
+                .fromHttpUrl(properties.getBaseUrl())
+                .path(EASY_DRUG_PATH)
+                .queryParam("serviceKey", properties.getServiceKey())
+                .queryParam("type", "json")
+                .queryParam("itemSeq", itemSeq.trim())
+                .queryParam("pageNo", 1)
+                .queryParam("numOfRows", 1)
+                .build(true)
+                .toUri();
+
+        try {
+            ResponseEntity<MfdsEasyDrugResponse> response =
+                    restTemplate.getForEntity(uri, MfdsEasyDrugResponse.class);
+            MfdsEasyDrugResponse body = response.getBody();
+
+            if (body == null || body.getBody() == null) {
+                log.warn("MFDS easy drug response body is empty for itemSeq={}", itemSeq);
+                return Optional.empty();
+            }
+
+            if (!"00".equals(body.getHeader().getResultCode())) {
+                log.warn("MFDS easy drug response error. code={}, message={}",
+                        body.getHeader().getResultCode(), body.getHeader().getResultMsg());
+                return Optional.empty();
+            }
+
+            MfdsEasyDrugBody bodyData = body.getBody();
+            List<MfdsEasyDrugItem> items = bodyData.getItems();
+            if (items == null || items.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(items.get(0));
+        } catch (Exception ex) {
+            log.error("MFDS easy drug API call failed for itemSeq={}", itemSeq, ex);
+            return Optional.empty();
+        }
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Service/MfdsDrugIngredientClient.java
+++ b/src/main/java/com/pillmate/pillmate/Service/MfdsDrugIngredientClient.java
@@ -1,0 +1,62 @@
+package com.pillmate.pillmate.Service;
+
+import java.net.URI;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.pillmate.pillmate.Config.MfdsApiProperties;
+import com.pillmate.pillmate.Service.dto.MfdsIngredientResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MfdsDrugIngredientClient {
+
+    private static final String INGREDIENT_PATH = "/DrbItemIngrRcpeInfoService/getDrbItemIngrRcpeList";
+
+    private final RestTemplate restTemplate;
+    private final MfdsApiProperties properties;
+
+    public List<MfdsIngredientResponse.Item> fetchIngredients(String itemSeq) {
+        URI uri = UriComponentsBuilder
+                .fromHttpUrl(properties.getBaseUrl())
+                .path(INGREDIENT_PATH)
+                .queryParam("serviceKey", properties.getServiceKey())
+                .queryParam("type", "json")
+                .queryParam("itemSeq", itemSeq)
+                .queryParam("pageNo", 1)
+                .queryParam("numOfRows", 100)
+                .build(true)
+                .toUri();
+
+        try {
+            ResponseEntity<MfdsIngredientResponse> response =
+                    restTemplate.getForEntity(uri, MfdsIngredientResponse.class);
+
+            MfdsIngredientResponse body = response.getBody();
+            if (body == null || body.getBody() == null) {
+                log.warn("MFDS ingredient response body empty for itemSeq={}", itemSeq);
+                return List.of();
+            }
+
+            if (!"00".equals(body.getHeader().getResultCode())) {
+                log.warn("MFDS ingredient response error. code={}, message={}",
+                        body.getHeader().getResultCode(), body.getHeader().getResultMsg());
+                return List.of();
+            }
+
+            return body.getBody().getItems();
+        } catch (Exception ex) {
+            log.error("MFDS ingredient API call failed for itemSeq={}", itemSeq, ex);
+            return List.of();
+        }
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Service/MfdsDrugPermissionClient.java
+++ b/src/main/java/com/pillmate/pillmate/Service/MfdsDrugPermissionClient.java
@@ -1,0 +1,67 @@
+package com.pillmate.pillmate.Service;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.pillmate.pillmate.Config.MfdsApiProperties;
+import com.pillmate.pillmate.Service.dto.MfdsPermissionResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MfdsDrugPermissionClient {
+
+    private static final String PERMISSION_PATH = "/DrugPrdtPrmsnInfoService07/getDrugPrdtPrmsnInq07";
+
+    private final RestTemplate restTemplate;
+    private final MfdsApiProperties properties;
+
+    public Optional<MfdsPermissionResponse.PermissionItem> fetchPermission(String itemSeq) {
+        URI uri = UriComponentsBuilder
+                .fromHttpUrl(properties.getBaseUrl())
+                .path(PERMISSION_PATH)
+                .queryParam("serviceKey", properties.getServiceKey())
+                .queryParam("type", "json")
+                .queryParam("prdlst_Stdr_code", itemSeq)
+                .queryParam("pageNo", 1)
+                .queryParam("numOfRows", 1)
+                .build(true)
+                .toUri();
+
+        try {
+            ResponseEntity<MfdsPermissionResponse> response =
+                    restTemplate.getForEntity(uri, MfdsPermissionResponse.class);
+
+            MfdsPermissionResponse body = response.getBody();
+            if (body == null || body.getBody() == null) {
+                log.warn("MFDS permission response body empty for itemSeq={}", itemSeq);
+                return Optional.empty();
+            }
+
+            if (!"00".equals(body.getHeader().getResultCode())) {
+                log.warn("MFDS permission response error. code={}, message={}",
+                        body.getHeader().getResultCode(), body.getHeader().getResultMsg());
+                return Optional.empty();
+            }
+
+            List<MfdsPermissionResponse.PermissionItem> items = body.getBody().getItems();
+            if (items == null || items.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.ofNullable(items.get(0));
+        } catch (Exception ex) {
+            log.error("MFDS permission API call failed for itemSeq={}", itemSeq, ex);
+            return Optional.empty();
+        }
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Service/dto/MfdsEasyDrugResponse.java
+++ b/src/main/java/com/pillmate/pillmate/Service/dto/MfdsEasyDrugResponse.java
@@ -1,0 +1,99 @@
+package com.pillmate.pillmate.Service.dto;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MfdsEasyDrugResponse {
+
+    @JsonProperty("header")
+    private MfdsEasyDrugHeader header;
+
+    @JsonProperty("body")
+    private MfdsEasyDrugBody body;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class MfdsEasyDrugHeader {
+        @JsonProperty("resultCode")
+        private String resultCode;
+
+        @JsonProperty("resultMsg")
+        private String resultMsg;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class MfdsEasyDrugBody {
+        @JsonProperty("totalCount")
+        private Integer totalCount;
+
+        @JsonProperty("items")
+        private List<MfdsEasyDrugItem> items;
+
+        public List<MfdsEasyDrugItem> getItems() {
+            return items == null ? Collections.emptyList() : items;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class MfdsEasyDrugItem {
+        @JsonProperty("itemSeq")
+        private String itemSeq;
+
+        @JsonProperty("itemName")
+        private String itemName;
+
+        @JsonProperty("entpName")
+        private String entpName;
+
+        @JsonProperty("etcOtcName")
+        private String etcOtcName;
+
+        @JsonProperty("chart")
+        private String chart;
+
+        @JsonProperty("itemImage")
+        private String itemImage;
+
+        @JsonProperty("efcyQesitm")
+        private String efcyQesitm;
+
+        @JsonProperty("useMethodQesitm")
+        private String useMethodQesitm;
+
+        @JsonProperty("atpnWarnQesitm")
+        private String atpnWarnQesitm;
+
+        @JsonProperty("atpnQesitm")
+        private String atpnQesitm;
+
+        @JsonProperty("intrcQesitm")
+        private String intrcQesitm;
+
+        @JsonProperty("seQesitm")
+        private String seQesitm;
+
+        @JsonProperty("depositMethodQesitm")
+        private String depositMethodQesitm;
+
+        @JsonProperty("openDe")
+        private String openDe;
+
+        @JsonProperty("updateDe")
+        private String updateDe;
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Service/dto/MfdsIngredientResponse.java
+++ b/src/main/java/com/pillmate/pillmate/Service/dto/MfdsIngredientResponse.java
@@ -1,0 +1,75 @@
+package com.pillmate.pillmate.Service.dto;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MfdsIngredientResponse {
+
+    @JsonProperty("header")
+    private Header header;
+
+    @JsonProperty("body")
+    private Body body;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Header {
+        @JsonProperty("resultCode")
+        private String resultCode;
+
+        @JsonProperty("resultMsg")
+        private String resultMsg;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Body {
+        @JsonProperty("totalCount")
+        private Integer totalCount;
+
+        @JsonProperty("items")
+        private List<Item> items;
+
+        public List<Item> getItems() {
+            return items == null ? Collections.emptyList() : items;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Item {
+        @JsonProperty("itemSeq")
+        private String itemSeq;
+
+        @JsonProperty("ingrCode")
+        private String ingredientCode;
+
+        @JsonProperty("ingrName")
+        private String ingredientName;
+
+        @JsonProperty("ingrEngName")
+        private String ingredientEngName;
+
+        @JsonProperty("mainIngr")
+        private String mainIngredient; // "Y" or "N"
+
+        @JsonProperty("unit")
+        private String unit;
+
+        @JsonProperty("content")
+        private String content;
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Service/dto/MfdsPermissionResponse.java
+++ b/src/main/java/com/pillmate/pillmate/Service/dto/MfdsPermissionResponse.java
@@ -1,0 +1,154 @@
+package com.pillmate.pillmate.Service.dto;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MfdsPermissionResponse {
+
+    @JsonProperty("header")
+    private Header header;
+
+    @JsonProperty("body")
+    private Body body;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Header {
+        @JsonProperty("resultCode")
+        private String resultCode;
+
+        @JsonProperty("resultMsg")
+        private String resultMsg;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Body {
+        @JsonProperty("totalCount")
+        private Integer totalCount;
+
+        @JsonProperty("items")
+        private List<PermissionItem> items;
+
+        public List<PermissionItem> getItems() {
+            return items == null ? Collections.emptyList() : items;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PermissionItem {
+        @JsonProperty("PRDLST_STDR_CODE")
+        private String prdlstStdrCodeUpper;
+
+        @JsonProperty("prdlstStdrCode")
+        private String prdlstStdrCode;
+
+        @JsonProperty("ITEM_NAME")
+        private String itemNameUpper;
+
+        @JsonProperty("itemName")
+        private String itemName;
+
+        @JsonProperty("SPCLTY_PBLC")
+        private String spcltyPblcUpper;
+
+        @JsonProperty("spcltyPblc")
+        private String spcltyPblc;
+
+        @JsonProperty("ETC_OTC_CODE")
+        private String etcOtcCodeUpper;
+
+        @JsonProperty("etcOtcCode")
+        private String etcOtcCode;
+
+        @JsonProperty("ITEM_INGR_NAME")
+        private String itemIngrNameUpper;
+
+        @JsonProperty("itemIngrName")
+        private String itemIngrName;
+
+        @JsonProperty("ATC_CODE")
+        private String atcCodeUpper;
+
+        @JsonProperty("atcCode")
+        private String atcCode;
+
+        @JsonProperty("STORAGE_METHOD")
+        private String storageMethodUpper;
+
+        @JsonProperty("storageMethod")
+        private String storageMethod;
+
+        @JsonProperty("PERMIT_DATE")
+        private String permitDateUpper;
+
+        @JsonProperty("permitDate")
+        private String permitDate;
+
+        @JsonProperty("APPRNC")
+        private String appearanceUpper;
+
+        @JsonProperty("apprnc")
+        private String appearance;
+
+        public String getResolvedItemSeq() {
+            return firstNonBlank(prdlstStdrCode, prdlstStdrCodeUpper);
+        }
+
+        public String getResolvedItemName() {
+            return firstNonBlank(itemName, itemNameUpper);
+        }
+
+        public String getResolvedSpcltyPblc() {
+            return firstNonBlank(spcltyPblc, spcltyPblcUpper);
+        }
+
+        public String getResolvedEtcOtcCode() {
+            return firstNonBlank(etcOtcCode, etcOtcCodeUpper);
+        }
+
+        public String getResolvedMainIngredient() {
+            return firstNonBlank(itemIngrName, itemIngrNameUpper);
+        }
+
+        public String getResolvedAtcCode() {
+            return firstNonBlank(atcCode, atcCodeUpper);
+        }
+
+        public String getResolvedStorageMethod() {
+            return firstNonBlank(storageMethod, storageMethodUpper);
+        }
+
+        public String getResolvedPermitDate() {
+            return firstNonBlank(permitDate, permitDateUpper);
+        }
+
+        public String getResolvedAppearance() {
+            return firstNonBlank(appearance, appearanceUpper);
+        }
+
+        private String firstNonBlank(String... values) {
+            if (values == null) return null;
+            for (String value : values) {
+                if (value != null && !value.trim().isEmpty()) {
+                    return value.trim();
+                }
+            }
+            return null;
+        }
+    }
+}
+


### PR DESCRIPTION
## 📌 변경 사항
- 식약처 의약품 제품 허가정보 API를 연동해 약품 상세 조회 시 허가 정보(전문/일반 구분 등)를 보완했습니다.
- e약은요 기본·성분 API와 허가정보 API 결과를 통합하도록 클라이언트와 서비스 로직을 확장했습니다.

## 🔍 상세 내용
- `MfdsDrugPermissionClient`와 `MfdsPermissionResponse`를 추가해 `DrugPrdtPrmsnInfoService07` 엔드포인트를 호출합니다.
- `DrugDetailService`에서 허가정보를 함께 조회해 `rxType` 등의 누락값을 보완하고, 공식 데이터가 없는 경우 “공식 데이터 미제공”으로 안내합니다.
- `DrugDetailResponse` 및 컨트롤러 swagger 설명을 최신화했습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 허가정보 API 응답이 없을 때 처리(“공식 데이터 미제공”) 방식이 적절한지 검토 부탁드립니다.
- 추가로 활용하면 좋을 허가 필드(허가일자, 보관방법 등)가 있다면 의견 주세요.

## 📎 참고 자료 (선택)
- 식품의약품안전처 의약품 제품 허가정보: https://www.data.go.kr/data/15095677/openapi.do