### PR TITLE
[BE-#75] 이메일 중복확인 API 구현

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Config/SecurityConfig.java
+++ b/src/main/java/com/pillmate/pillmate/Config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(authz -> authz
                 .requestMatchers("/api/auth/**").permitAll() // 인증 API 허용 (기존 경로)
-                .requestMatchers("/api/v1/signup", "/api/v1/auth/login").permitAll() // 회원가입, 로그인 API 허용
+                .requestMatchers("/api/v1/signup", "/api/v1/signup/**", "/api/v1/auth/login").permitAll() // 회원가입, 이메일 확인, 로그인 허용
                 .requestMatchers("/oauth2/**", "/login/**").permitAll() // OAuth2 소셜 로그인 관련 요청 허용
                 .requestMatchers("/swagger.html", "/swagger-ui/**", "/api-docs/**").permitAll() // Swagger 허용
                 .requestMatchers("/h2-console/**").permitAll() // H2 콘솔 허용 (개발용)

--- a/src/main/java/com/pillmate/pillmate/Controller/AuthController.java
+++ b/src/main/java/com/pillmate/pillmate/Controller/AuthController.java
@@ -5,9 +5,11 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.pillmate.pillmate.Config.JwtUtil;
@@ -16,6 +18,7 @@ import com.pillmate.pillmate.DTO.LoginRequest;
 import com.pillmate.pillmate.DTO.LoginResponse;
 import com.pillmate.pillmate.DTO.SignUpRequest;
 import com.pillmate.pillmate.DTO.SignUpResponse;
+import com.pillmate.pillmate.DTO.EmailAvailabilityResponse;
 import com.pillmate.pillmate.Domain.User;
 import com.pillmate.pillmate.Service.UserService;
 
@@ -34,6 +37,29 @@ public class AuthController {
     
     private final UserService userService;
     private final JwtUtil jwtUtil;
+    
+    @Operation(summary = "이메일 중복 확인", description = "이메일 형식과 중복 여부를 검증합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용 가능한 이메일"),
+        @ApiResponse(responseCode = "400", description = "잘못된 이메일 형식"),
+        @ApiResponse(responseCode = "409", description = "중복된 이메일")
+    })
+    @GetMapping("/signup/check-email")
+    public ResponseEntity<EmailAvailabilityResponse> checkEmail(@RequestParam("email") String email) {
+        String normalized = email == null ? null : email.trim();
+        boolean available = userService.checkEmailAvailability(normalized);
+
+        EmailAvailabilityResponse response = EmailAvailabilityResponse.builder()
+                .message("사용 가능한 이메일입니다.")
+                .success(true)
+                .data(EmailAvailabilityResponse.Data.builder()
+                        .email(normalized)
+                        .isAvailable(available)
+                        .build())
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
     
     @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/pillmate/pillmate/DTO/EmailAvailabilityResponse.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/EmailAvailabilityResponse.java
@@ -1,0 +1,27 @@
+package com.pillmate.pillmate.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailAvailabilityResponse {
+
+    private String message;
+    private boolean success;
+    private Data data;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Data {
+        private String email;
+        private boolean isAvailable;
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Service/UserService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/UserService.java
@@ -1,7 +1,11 @@
 package com.pillmate.pillmate.Service;
 
+import java.util.regex.Pattern;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.pillmate.pillmate.DTO.BasicProfileResponse;
 import com.pillmate.pillmate.DTO.BasicProfileUpdateRequest;
@@ -21,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
     
     private final UserRepository userRepository;
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
     
     // 회원가입
     @Transactional
@@ -52,6 +57,17 @@ public class UserService {
         
         // 저장
         return userRepository.save(user);
+    }
+    
+    public boolean checkEmailAvailability(String email) {
+        String normalized = email == null ? null : email.trim();
+        if (normalized == null || normalized.isBlank() || !EMAIL_PATTERN.matcher(normalized).matches()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 형식입니다.");
+        }
+        if (userRepository.existsByEmail(normalized)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.");
+        }
+        return true;
     }
     
     // 로그인


### PR DESCRIPTION
## 📌 변경 사항
- `GET /api/v1/signup/check-email` 엔드포인트 추가로 이메일 형식 및 중복 여부 검사 지원
- `UserService`에 이메일 정규식 검증 및 중복 확인 로직 도입
- 응답 스키마 전용 DTO(`EmailAvailabilityResponse`) 생성
- `SecurityConfig` 수정으로 이메일 중복 확인 API를 인증 없이 접근 가능하도록 허용

## 🔍 상세 내용
- `AuthController`에서 이메일 파라미터를 정규화한 뒤 서비스 레이어 호출 → 성공 시 메시지/성공 여부/입력 이메일을 포함한 응답 반환
- `UserService.checkEmailAvailability`에서 정규식 기반 형식 검증 후, 이미 존재하는 이메일이면 `ResponseStatusException`으로 409 반환
- 신규 DTO로 프론트가 요구한 응답 구조(`message`, `success`, `data.email`, `data.isAvailable`)를 그대로 제공
- `SecurityConfig`의 `requestMatchers`에 `/api/v1/signup/**` 패턴을 추가해 인증 없이 호출 가능하도록 조정

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 이메일 정규식 패턴이 요구사항에 맞는지 검토 부탁드립니다.
- 이메일 검증 실패/중복 시 HTTP 상태 코드 매핑이 기대와 일치하는지 확인 부탁드립니다.

## 📎 참고 자료 (선택)
- 해당 없음