### PR TITLE
[BE-#77] 첫 로그인 여부 관련 boolean 필드 추가

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Controller/AuthController.java
+++ b/src/main/java/com/pillmate/pillmate/Controller/AuthController.java
@@ -21,6 +21,7 @@ import com.pillmate.pillmate.DTO.SignUpResponse;
 import com.pillmate.pillmate.DTO.EmailAvailabilityResponse;
 import com.pillmate.pillmate.Domain.User;
 import com.pillmate.pillmate.Service.UserService;
+import com.pillmate.pillmate.Service.UserService.LoginResult;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -120,7 +121,8 @@ public class AuthController {
     @PostMapping("/auth/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
         try {
-            User user = userService.login(request.getEmail(), request.getPassword());
+            LoginResult loginResult = userService.login(request.getEmail(), request.getPassword());
+            User user = loginResult.getUser();
             
             // JWT 토큰 생성
             String accessToken = jwtUtil.generateToken(user.getEmail());
@@ -138,6 +140,7 @@ public class AuthController {
                     .tokenType("Bearer")
                     .expiresInMillis(jwtUtil.getExpirationTimeMillis())
                     .user(userInfo)
+                    .firstLogin(loginResult.isFirstLogin())
                     .build();
             
             return ResponseEntity.ok(response);

--- a/src/main/java/com/pillmate/pillmate/DTO/LoginResponse.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/LoginResponse.java
@@ -15,6 +15,7 @@ public class LoginResponse {
     private String tokenType;
     private Long expiresInMillis;
     private UserInfo user;
+    private boolean firstLogin;
     
     @Getter
     @Builder

--- a/src/main/java/com/pillmate/pillmate/Domain/User.java
+++ b/src/main/java/com/pillmate/pillmate/Domain/User.java
@@ -92,6 +92,13 @@ public class User {
     @Column(nullable = false, columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
     private LocalDateTime updatedAt;
 
+    @Column(columnDefinition = "DATETIME")
+    private LocalDateTime lastLoginAt;
+
+    @Builder.Default
+    @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
+    private Integer loginCount = 0;
+
     // 비밀번호 암호화 메서드
     public void encodePassword(String rawPassword) {
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
@@ -130,6 +137,17 @@ public class User {
         user.termsOfService = true;  // 소셜 로그인 시 약관 동의로 간주
         user.privacyPolicy = true;
         user.dataUsage = false;  // 선택 약관은 false
+        user.loginCount = 0;
         return user;
+    }
+
+    public boolean markLogin() {
+        boolean isFirst = loginCount == null || loginCount == 0;
+        if (loginCount == null) {
+            loginCount = 0;
+        }
+        loginCount += 1;
+        lastLoginAt = LocalDateTime.now();
+        return isFirst;
     }
 }

--- a/src/main/java/com/pillmate/pillmate/Security/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/pillmate/pillmate/Security/OAuth2/OAuth2SuccessHandler.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pillmate.pillmate.Config.JwtUtil;
 import com.pillmate.pillmate.DTO.LoginResponse;
 import com.pillmate.pillmate.Security.CustomUserDetails;
+import com.pillmate.pillmate.Service.UserService;
+import com.pillmate.pillmate.Service.UserService.LoginResult;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,13 +24,15 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     
     private final JwtUtil jwtUtil;
     private final ObjectMapper objectMapper;
+    private final UserService userService;
     
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
         
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        
+        boolean firstLogin = userService.markLogin(userDetails.getId());
+
         // JWT 토큰 생성
         String accessToken = jwtUtil.generateToken(userDetails.getEmail());
         
@@ -45,6 +49,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 .tokenType("Bearer")
                 .expiresInMillis(jwtUtil.getExpirationTimeMillis())
                 .user(userInfo)
+                .firstLogin(firstLogin)
                 .build();
         
         // 응답

--- a/src/main/java/com/pillmate/pillmate/Service/UserService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/UserService.java
@@ -16,6 +16,8 @@ import com.pillmate.pillmate.Domain.AuthProvider;
 import com.pillmate.pillmate.Domain.User;
 import com.pillmate.pillmate.Repository.UserRepository;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 
@@ -71,7 +73,8 @@ public class UserService {
     }
     
     // 로그인
-    public User login(String email, String password) {
+    @Transactional
+    public LoginResult login(String email, String password) {
         User user = findByEmail(email);
         
         // 비밀번호 검증
@@ -79,7 +82,15 @@ public class UserService {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다");
         }
         
-        return user;
+        boolean firstLogin = user.markLogin();
+        return new LoginResult(user, firstLogin);
+    }
+    
+    @Transactional
+    public boolean markLogin(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+        return user.markLogin();
     }
     
     // 이메일로 사용자 찾기
@@ -132,5 +143,12 @@ public class UserService {
         );
 
         return BasicProfileResponse.from(user);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class LoginResult {
+        private final User user;
+        private final boolean firstLogin;
     }
 }


### PR DESCRIPTION
## 📌 변경 사항
- 로그인 응답에 `firstLogin` 플래그 추가
- `User` 엔티티에 `lastLoginAt`, `loginCount` 필드 도입 및 로그인 시각/횟수 관리
- 일반 로그인 및 OAuth2 로그인 흐름에서 최초 로그인 여부 판별 로직 적용

## 🔍 상세 내용
- `User.markLogin()`에서 로그인 시각 갱신과 카운트 증가를 수행하고, 최초 로그인 여부를 반환
- `UserService.login`과 `UserService.markLogin`을 통해 각각 비밀번호 기반 로그인과 소셜 로그인에서 동일한 처리 구현
- `AuthController`와 `OAuth2SuccessHandler`가 `firstLogin` 값을 `LoginResponse`에 포함해 프런트가 라우팅을 제어할 수 있도록 함

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- DB 스키마 변경(`last_login_at`, `login_count`)이 배포 환경에서도 문제없이 반영되는지 확인 부탁드립니다.
- 소셜 로그인 성공 시에도 `firstLogin` 전달이 기대대로 동작하는지 점검 부탁드립니다.

## 📎 참고 자료 (선택)
- 해당 사항 없음