### PR TITLE
[BE-#81] 카카오 소셜 로그인 API 구현

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Security/OAuth2/KakaoOAuth2UserService.java
+++ b/src/main/java/com/pillmate/pillmate/Security/OAuth2/KakaoOAuth2UserService.java
@@ -1,0 +1,126 @@
+package com.pillmate.pillmate.Security.OAuth2;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pillmate.pillmate.Domain.AuthProvider;
+import com.pillmate.pillmate.Domain.User;
+import com.pillmate.pillmate.Repository.UserRepository;
+import com.pillmate.pillmate.Security.CustomUserDetails;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class KakaoOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private static final String DEFAULT_DISPLAY_NAME = "카카오사용자";
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        try {
+            OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+            OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+            Map<String, Object> attributes = oAuth2User.getAttributes();
+            log.info("카카오 OAuth2 사용자 속성: {}", attributes);
+
+            String providerId = extractProviderId(attributes);
+            String email = extractEmail(attributes);
+            String name = extractNickname(attributes, email);
+
+            log.info("추출된 카카오 사용자 정보 - providerId: {}, email: {}, name: {}", providerId, email, name);
+
+            if (providerId == null) {
+                throw new OAuth2AuthenticationException("카카오 인증 정보를 가져올 수 없습니다 (providerId 누락)");
+            }
+
+            if (email == null || email.isBlank()) {
+                throw new OAuth2AuthenticationException("카카오 계정 이메일 동의가 필요합니다");
+            }
+
+            final AuthProvider provider = AuthProvider.KAKAO;
+
+            Optional<User> existingUserOpt = userRepository.findByProviderAndProviderId(provider, providerId);
+            if (existingUserOpt.isPresent()) {
+                User existingUser = existingUserOpt.get();
+                log.info("기존 카카오 사용자 발견 - id: {}, email: {}", existingUser.getId(), existingUser.getEmail());
+                return new CustomUserDetails(existingUser);
+            }
+
+            Optional<User> existingUserByEmail = userRepository.findByEmail(email);
+            if (existingUserByEmail.isPresent()) {
+                User existingEmailUser = existingUserByEmail.get();
+                log.info("이메일로 기존 사용자 발견 - id: {}, provider: {}", existingEmailUser.getId(),
+                        existingEmailUser.getProvider());
+
+                if (existingEmailUser.getProvider() == AuthProvider.KAKAO) {
+                    return new CustomUserDetails(existingEmailUser);
+                } else {
+                    throw new OAuth2AuthenticationException("이미 다른 방식으로 가입된 이메일입니다");
+                }
+            }
+
+            User newUser = User.createSocialUser(email, name, provider, providerId);
+            User savedUser = userRepository.save(newUser);
+            log.info("새 카카오 사용자 생성 완료 - id: {}, email: {}", savedUser.getId(), savedUser.getEmail());
+            return new CustomUserDetails(savedUser);
+        } catch (OAuth2AuthenticationException e) {
+            log.error("카카오 OAuth2 인증 오류: {}", e.getMessage(), e);
+            throw e;
+        } catch (Exception e) {
+            log.error("카카오 OAuth2 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
+            OAuth2Error oauth2Error = new OAuth2Error("oauth2_error",
+                    "카카오 소셜 로그인 처리 중 오류가 발생했습니다: " + e.getMessage(), null);
+            throw new OAuth2AuthenticationException(oauth2Error, e);
+        }
+    }
+
+    private String extractProviderId(Map<String, Object> attributes) {
+        Object providerId = attributes.get("id");
+        return providerId != null ? String.valueOf(providerId) : null;
+    }
+
+    private String extractEmail(Map<String, Object> attributes) {
+        Object accountObj = attributes.get("kakao_account");
+        if (accountObj instanceof Map<?, ?> account) {
+            Object email = account.get("email");
+            if (email != null) {
+                return String.valueOf(email);
+            }
+        }
+        return null;
+    }
+
+    private String extractNickname(Map<String, Object> attributes, String fallbackEmail) {
+        Object accountObj = attributes.get("kakao_account");
+        if (accountObj instanceof Map<?, ?> account) {
+            Object profileObj = account.get("profile");
+            if (profileObj instanceof Map<?, ?> profile) {
+                Object nickname = profile.get("nickname");
+                if (nickname != null && !nickname.toString().isBlank()) {
+                    return nickname.toString();
+                }
+            }
+        }
+        if (fallbackEmail != null && !fallbackEmail.isBlank()) {
+            return fallbackEmail.split("@")[0];
+        }
+        return DEFAULT_DISPLAY_NAME;
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Security/OAuth2/OAuth2UserProviderRouter.java
+++ b/src/main/java/com/pillmate/pillmate/Security/OAuth2/OAuth2UserProviderRouter.java
@@ -13,7 +13,8 @@ import lombok.RequiredArgsConstructor;
 public class OAuth2UserProviderRouter implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
     
     private final GoogleOAuth2UserService googleOAuth2UserService;
-    // 추후 NaverOAuth2UserService, KakaoOAuth2UserService 등 추가 가능
+    private final KakaoOAuth2UserService kakaoOAuth2UserService;
+    // 추후 NaverOAuth2UserService 등 추가 가능
     
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -21,10 +22,11 @@ public class OAuth2UserProviderRouter implements OAuth2UserService<OAuth2UserReq
         
         return switch (provider) {
             case "google" -> googleOAuth2UserService.loadUser(userRequest);
+            case "kakao" -> kakaoOAuth2UserService.loadUser(userRequest);
             // case "naver" -> naverOAuth2UserService.loadUser(userRequest);
-            // case "kakao" -> kakaoOAuth2UserService.loadUser(userRequest);
             default -> throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다: " + provider);
         };
     }
 }
+
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,12 +36,26 @@ spring:
             scope:
               - profile
               - email
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID:}
+            client-secret: ${KAKAO_CLIENT_SECRET:}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - profile_nickname
+              - account_email
         provider:
           google:
             authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
             token-uri: https://oauth2.googleapis.com/token
             user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
             user-name-attribute: sub
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
 # 로깅 레벨 설정: SQL을 더 자세히 보고 싶을 때 사용
 logging:
@@ -49,6 +63,10 @@ logging:
     org.hibernate.SQL: debug # 실행되는 SQL 쿼리를 보여줌 (show-sql: true와 유사)
     org.hibernate.type: trace # SQL에 바인딩되는 파라미터 값을 보여줌 (매우 유용!)
     org.springframework.jdbc: debug
+    org.springframework.security.oauth2: debug
+    org.springframework.web.client.RestTemplate: debug
+    org.springframework.security.oauth2.client: trace
+    org.springframework.security.oauth2.core: trace
 
 # Swagger(OpenAPI) 설정
 springdoc:


### PR DESCRIPTION
## 📌 변경 사항
- 카카오 OAuth2 로그인을 추가하고 구글과 동일한 JWT 응답 흐름을 재사용하도록 구성했습니다.

## 🔍 상세 내용
- `application.yml`에 카카오 OAuth2 클라이언트/프로바이더 설정을 추가하고 스코프(`profile_nickname`, `account_email`)를 명시했습니다.
- 신규 `KakaoOAuth2UserService`를 도입해 카카오 사용자 정보를 조회·회원 가입·JWT 발급 로직에 연결했습니다.
- `OAuth2UserProviderRouter`에서 `kakao` 분기를 추가해 로그인 시 카카오 서비스가 호출되도록 했습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 카카오 사용자 정보 매핑 및 기존 사용자 식별 로직에 보완할 점이 있는지 검토 부탁드립니다.

## 📎 참고 자료 (선택)
- 별도 자료는 없습니다.