### PR TITLE
[BE-#20] 네이버 소셜 로그인 API 구현

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Security/OAuth2/NaverOAuth2UserService.java
+++ b/src/main/java/com/pillmate/pillmate/Security/OAuth2/NaverOAuth2UserService.java
@@ -1,0 +1,109 @@
+package com.pillmate.pillmate.Security.OAuth2;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pillmate.pillmate.Domain.AuthProvider;
+import com.pillmate.pillmate.Domain.User;
+import com.pillmate.pillmate.Repository.UserRepository;
+import com.pillmate.pillmate.Security.CustomUserDetails;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class NaverOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        try {
+            OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+            OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+            Map<String, Object> attributes = oAuth2User.getAttributes();
+            log.info("네이버 OAuth2 사용자 속성: {}", attributes);
+
+            Map<String, Object> response = extractResponse(attributes);
+            String providerId = getString(response.get("id"));
+            String email = getString(response.get("email"));
+            String nameAttribute = getString(response.get("name"));
+
+            log.info("추출된 네이버 사용자 정보 - providerId: {}, email: {}, name: {}", providerId, email, nameAttribute);
+
+            if (providerId == null) {
+                throw new OAuth2AuthenticationException("네이버 인증 정보를 가져올 수 없습니다 (providerId 누락)");
+            }
+
+            if (email == null || email.isBlank()) {
+                throw new OAuth2AuthenticationException("네이버 계정 이메일 동의가 필요합니다");
+            }
+
+            final String name = (nameAttribute == null || nameAttribute.isBlank())
+                    ? email.split("@")[0]
+                    : nameAttribute;
+
+            final AuthProvider provider = AuthProvider.NAVER;
+
+            Optional<User> existingUserOpt = userRepository.findByProviderAndProviderId(provider, providerId);
+            if (existingUserOpt.isPresent()) {
+                User existingUser = existingUserOpt.get();
+                log.info("기존 네이버 사용자 발견 - id: {}, email: {}", existingUser.getId(), existingUser.getEmail());
+                return new CustomUserDetails(existingUser);
+            }
+
+            Optional<User> existingUserByEmail = userRepository.findByEmail(email);
+            if (existingUserByEmail.isPresent()) {
+                User existingEmailUser = existingUserByEmail.get();
+                log.info("이메일로 기존 사용자 발견 - id: {}, provider: {}", existingEmailUser.getId(),
+                        existingEmailUser.getProvider());
+
+                if (existingEmailUser.getProvider() == AuthProvider.NAVER) {
+                    return new CustomUserDetails(existingEmailUser);
+                } else {
+                    throw new OAuth2AuthenticationException("이미 다른 방식으로 가입된 이메일입니다");
+                }
+            }
+
+            User newUser = User.createSocialUser(email, name, provider, providerId);
+            User savedUser = userRepository.save(newUser);
+            log.info("새 네이버 사용자 생성 완료 - id: {}, email: {}", savedUser.getId(), savedUser.getEmail());
+            return new CustomUserDetails(savedUser);
+        } catch (OAuth2AuthenticationException e) {
+            log.error("네이버 OAuth2 인증 오류: {}", e.getMessage(), e);
+            throw e;
+        } catch (Exception e) {
+            log.error("네이버 OAuth2 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
+            OAuth2Error oauth2Error = new OAuth2Error("oauth2_error",
+                    "네이버 소셜 로그인 처리 중 오류가 발생했습니다: " + e.getMessage(), null);
+            throw new OAuth2AuthenticationException(oauth2Error, e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> extractResponse(Map<String, Object> attributes) {
+        Object responseObj = attributes.get("response");
+        if (responseObj instanceof Map<?, ?> responseMap) {
+            return (Map<String, Object>) responseMap;
+        }
+        throw new OAuth2AuthenticationException("네이버 사용자 정보(response)가 존재하지 않습니다");
+    }
+
+    private String getString(Object value) {
+        return value == null ? null : value.toString();
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Security/OAuth2/OAuth2UserProviderRouter.java
+++ b/src/main/java/com/pillmate/pillmate/Security/OAuth2/OAuth2UserProviderRouter.java
@@ -14,6 +14,7 @@ public class OAuth2UserProviderRouter implements OAuth2UserService<OAuth2UserReq
     
     private final GoogleOAuth2UserService googleOAuth2UserService;
     private final KakaoOAuth2UserService kakaoOAuth2UserService;
+    private final NaverOAuth2UserService naverOAuth2UserService;
     // 추후 NaverOAuth2UserService 등 추가 가능
     
     @Override
@@ -23,7 +24,7 @@ public class OAuth2UserProviderRouter implements OAuth2UserService<OAuth2UserReq
         return switch (provider) {
             case "google" -> googleOAuth2UserService.loadUser(userRequest);
             case "kakao" -> kakaoOAuth2UserService.loadUser(userRequest);
-            // case "naver" -> naverOAuth2UserService.loadUser(userRequest);
+            case "naver" -> naverOAuth2UserService.loadUser(userRequest);
             default -> throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다: " + provider);
         };
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,15 @@ spring:
             scope:
               - profile_nickname
               - account_email
+          naver:
+            client-id: ${NAVER_CLIENT_ID:}
+            client-secret: ${NAVER_CLIENT_SECRET:}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - name
+              - email
         provider:
           google:
             authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
@@ -56,6 +65,11 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
 
 # 로깅 레벨 설정: SQL을 더 자세히 보고 싶을 때 사용
 logging:


### PR DESCRIPTION
## 📌 변경 사항
- 네이버 OAuth2 로그인을 추가하고 기존 카카오/구글과 동일한 JWT 응답 구조로 통합했습니다.

## 🔍 상세 내용
- `application.yml`에 네이버 OAuth 클라이언트/프로바이더 설정을 추가하고 `NAVER_CLIENT_ID`, `NAVER_CLIENT_SECRET` 환경 변수를 사용하도록 구성했습니다.
- 신규 `NaverOAuth2UserService`를 구현해 네이버 사용자 정보를 조회·회원 가입·JWT 발급 로직에 연결했습니다.
- `OAuth2UserProviderRouter`에서 `naver` 분기를 추가해 네이버 로그인 시 해당 서비스가 실행되도록 했습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 네이버 사용자 정보 매핑 및 기존 사용자 예외 처리 흐름이 예상대로 동작하는지 확인 부탁드립니다.

## 📎 참고 자료 (선택)
- 별도 자료는 없습니다.