### PR TITLE
[BE-#84] 성분, 함량 DB 매핑

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Domain/DrugManualOverride.java
+++ b/src/main/java/com/pillmate/pillmate/Domain/DrugManualOverride.java
@@ -1,0 +1,45 @@
+package com.pillmate.pillmate.Domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Entity
+@Table(name = "drug_manual_overrides")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DrugManualOverride {
+
+    @Id
+    @Column(length = 32, nullable = false)
+    private String drugId;
+
+    @Column(length = 255)
+    private String strength;
+
+    @Column(name = "ingredients_csv", length = 1000)
+    private String ingredientsCsv;
+
+    public List<String> getIngredients() {
+        if (!StringUtils.hasText(ingredientsCsv)) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(ingredientsCsv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/Repository/DrugManualOverrideRepository.java
+++ b/src/main/java/com/pillmate/pillmate/Repository/DrugManualOverrideRepository.java
@@ -1,0 +1,10 @@
+package com.pillmate.pillmate.Repository;
+
+import com.pillmate.pillmate.Domain.DrugManualOverride;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DrugManualOverrideRepository extends JpaRepository<DrugManualOverride, String> {
+}
+

--- a/src/main/java/com/pillmate/pillmate/Service/DrugDetailService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/DrugDetailService.java
@@ -17,6 +17,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.pillmate.pillmate.DTO.DrugDetailResponse;
+import com.pillmate.pillmate.Domain.DrugManualOverride;
+import com.pillmate.pillmate.Repository.DrugManualOverrideRepository;
 import com.pillmate.pillmate.Service.dto.MfdsEasyDrugResponse.MfdsEasyDrugItem;
 import com.pillmate.pillmate.Service.dto.MfdsIngredientResponse;
 import com.pillmate.pillmate.Service.dto.MfdsPermissionResponse;
@@ -33,6 +35,7 @@ public class DrugDetailService {
     private final MfdsDrugInfoClient mfdsDrugInfoClient;
     private final MfdsDrugIngredientClient mfdsDrugIngredientClient;
     private final MfdsDrugPermissionClient mfdsDrugPermissionClient;
+    private final DrugManualOverrideRepository drugManualOverrideRepository;
 
     public DrugDetailResponse fetchDrugDetail(String drugId) {
         MfdsEasyDrugItem item = mfdsDrugInfoClient.fetchEasyDrug(drugId)
@@ -48,6 +51,16 @@ public class DrugDetailService {
                 .filter(StringUtils::hasText)
                 .distinct()
                 .collect(Collectors.toList());
+
+        DrugManualOverride override = drugManualOverrideRepository.findById(drugId).orElse(null);
+        String resolvedStrength = firstNonBlank(
+                Optional.ofNullable(override).map(DrugManualOverride::getStrength).orElse(null),
+                strength
+        );
+        List<String> resolvedIngredients = Optional.ofNullable(override)
+                .map(DrugManualOverride::getIngredients)
+                .filter(list -> !list.isEmpty())
+                .orElse(ingredients);
 
         Optional<MfdsPermissionResponse.PermissionItem> permissionOpt = mfdsDrugPermissionClient.fetchPermission(drugId);
         String resolvedRxType = firstNonBlank(
@@ -71,8 +84,8 @@ public class DrugDetailService {
                 .name(item.getItemName())
                 .entpName(item.getEntpName())
                 .rxType(withFallback(resolvedRxType, "공식 데이터 미제공"))
-                .strength(withFallback(strength, "공식 데이터 미제공"))
-                .ingredients(ingredients.isEmpty() ? List.of("공식 데이터 미제공") : ingredients)
+                .strength(withFallback(resolvedStrength, "공식 데이터 미제공"))
+                .ingredients(resolvedIngredients.isEmpty() ? List.of("공식 데이터 미제공") : resolvedIngredients)
                 .efficacy(clean(item.getEfcyQesitm()))
                 .dosage(clean(item.getUseMethodQesitm()))
                 .cautions(clean(cautions))

--- a/src/main/resources/migration.sql
+++ b/src/main/resources/migration.sql
@@ -1,0 +1,37 @@
+-- 회원가입 API를 위한 users 테이블 마이그레이션
+-- 기존 테이블이 있는 경우에 실행할 SQL 스크립트
+
+-- 1. 약관 동의 필드 추가 (없는 경우에만)
+ALTER TABLE users 
+ADD COLUMN IF NOT EXISTS terms_of_service BOOLEAN NOT NULL DEFAULT FALSE COMMENT '서비스 이용약관 동의 여부';
+
+ALTER TABLE users 
+ADD COLUMN IF NOT EXISTS privacy_policy BOOLEAN NOT NULL DEFAULT FALSE COMMENT '개인정보 처리방침 동의 여부';
+
+ALTER TABLE users 
+ADD COLUMN IF NOT EXISTS data_usage BOOLEAN NOT NULL DEFAULT FALSE COMMENT '데이터 활용 동의 여부';
+
+-- 2. 생성일시, 수정일시 필드 추가 (없는 경우에만)
+ALTER TABLE users 
+ADD COLUMN IF NOT EXISTS created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '회원 생성 시각';
+
+ALTER TABLE users 
+ADD COLUMN IF NOT EXISTS updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '정보 최종 수정 시각';
+
+-- 3. name 컬럼 길이 변경 (50 -> 20)
+ALTER TABLE users 
+MODIFY COLUMN name VARCHAR(20) NOT NULL COMMENT '사용자 이름';
+
+-- 참고: MySQL 8.0 이상에서 IF NOT EXISTS를 사용할 수 없으므로, 
+-- 아래와 같이 수동으로 확인 후 실행해야 할 수 있습니다.
+
+
+-- 4. 수동 약품 보강 테이블 생성 (없으면 생성)
+CREATE TABLE IF NOT EXISTS drug_manual_overrides (
+    drug_id VARCHAR(32) NOT NULL COMMENT '식약처 품목기준코드',
+    strength VARCHAR(255) COMMENT '수동으로 정의한 함량 정보',
+    ingredients_csv VARCHAR(1000) COMMENT '쉼표로 구분된 주요 성분 목록',
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '최종 수정 시각',
+    PRIMARY KEY (drug_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='식약처 API 보완용 약품 정보';
+

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,45 @@
+-- users 테이블 생성 스크립트 (새로 테이블을 만드는 경우)
+
+CREATE TABLE IF NOT EXISTS users (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(20) NOT NULL COMMENT '사용자 이름',
+    email VARCHAR(100) NOT NULL UNIQUE COMMENT '이메일',
+    password VARCHAR(255) NOT NULL COMMENT '비밀번호 (암호화)',
+    terms_of_service BOOLEAN NOT NULL DEFAULT FALSE COMMENT '서비스 이용약관 동의 여부',
+    privacy_policy BOOLEAN NOT NULL DEFAULT FALSE COMMENT '개인정보 처리방침 동의 여부',
+    data_usage BOOLEAN NOT NULL DEFAULT FALSE COMMENT '데이터 활용 동의 여부',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '회원 생성 시각',
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '정보 최종 수정 시각',
+    INDEX idx_email (email)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 정보 테이블';
+
+-- schedules 테이블 생성 스크립트 (캘린더 복약 일정)
+
+CREATE TABLE IF NOT EXISTS schedules (
+    schedule_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    drug_id BIGINT NOT NULL COMMENT '약품 ID',
+    dose VARCHAR(100) NOT NULL COMMENT '복용량 또는 용법',
+    alarm_at DATETIME NOT NULL COMMENT '알림 시각',
+    memo TEXT COMMENT '사용자 메모',
+    alarm_enabled BOOLEAN NOT NULL DEFAULT FALSE COMMENT '알림 사용 여부',
+    repeat_rule VARCHAR(500) COMMENT '반복 규칙 (RFC5545 형식)',
+    start_date DATE NOT NULL COMMENT '복용 시작일',
+    end_date DATE NOT NULL COMMENT '복용 종료일',
+    status VARCHAR(20) NOT NULL DEFAULT 'SCHEDULED' COMMENT '일정 상태 (SCHEDULED, COMPLETED, MISSED, CANCELLED)',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '일정 생성 시각',
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '일정 수정 시각',
+    INDEX idx_drug_id (drug_id),
+    INDEX idx_alarm_at (alarm_at),
+    INDEX idx_date_range (start_date, end_date),
+    INDEX idx_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='캘린더 복약 일정 테이블';
+
+-- 약품 수동 보강 데이터를 저장하는 테이블
+CREATE TABLE IF NOT EXISTS drug_manual_overrides (
+    drug_id VARCHAR(32) NOT NULL COMMENT '식약처 품목기준코드',
+    strength VARCHAR(255) COMMENT '수동으로 정의한 함량 정보',
+    ingredients_csv VARCHAR(1000) COMMENT '쉼표로 구분된 주요 성분 목록',
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '최종 수정 시각',
+    PRIMARY KEY (drug_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='식약처 API 보완용 약품 정보';
+


### PR DESCRIPTION
## 📌 변경 사항
- 식약처 API에서 제공되지 않는 성분·함량 정보를 수동으로 보강할 수 있도록 `drug_manual_overrides` 테이블 및 엔티티 추가
- `DrugDetailService`에서 식약처 응답과 수동 보강 데이터를 병합해 상세 조회 응답으로 반환하도록 로직 개선
- `schema.sql`, `migration.sql`에 테이블 생성 스크립트 추가로 신규/기존 환경 동시 지원

## 🔍 상세 내용
- `DrugManualOverride` 엔티티 및 `DrugManualOverrideRepository`를 추가해 `drug_id` 기준 수동 보강 데이터를 조회할 수 있게 했습니다.
- `DrugDetailService.fetchDrugDetail`에서 수동 데이터가 존재하면 함량(`strength`)과 성분(`ingredients`)을 우선 적용하고, 없으면 기존 API 값을 사용하도록 병합 로직을 구현했습니다.
- 새 테이블 정의를 `schema.sql`, `migration.sql`에 반영해 초기 부트스트랩과 후속 마이그레이션 모두 동일한 구조를 유지합니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 수동 보강 데이터 우선순위(수동값 > API값 > “공식 데이터 미제공”)가 기대와 일치하는지 확인 부탁드립니다.
- 추가로 필요해 보이는 컬럼이나 관리 방식 아이디어 있으면 코멘트 부탁드려요.

## 📎 참고 자료 (선택)
- 팀 공유용: 수동 테이블 생성 및 테스트 절차 정리 (DB 매뉴얼 문서 참고)