### PR TITLE
[BE-#89] 알코올, 카페인 상호작용 DB 매핑

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Domain/DrugManualOverride.java
+++ b/src/main/java/com/pillmate/pillmate/Domain/DrugManualOverride.java
@@ -32,6 +32,12 @@ public class DrugManualOverride {
     @Column(name = "ingredients_csv", length = 1000)
     private String ingredientsCsv;
 
+    @Column(name = "caution_alcohol", length = 1000)
+    private String cautionAlcohol;
+
+    @Column(name = "caution_caffeine", length = 1000)
+    private String cautionCaffeine;
+
     public List<String> getIngredients() {
         if (!StringUtils.hasText(ingredientsCsv)) {
             return Collections.emptyList();

--- a/src/main/java/com/pillmate/pillmate/Service/DrugDetailService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/DrugDetailService.java
@@ -10,8 +10,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import com.pillmate.pillmate.Service.MfdsDrugInfoClient;
-
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.http.HttpStatus;
@@ -79,6 +77,10 @@ public class DrugDetailService {
         );
 
         Map<String, String> summary = buildCautionSummary(cautions);
+        if (override != null) {
+            applyCautionOverride(summary, "alcohol", override.getCautionAlcohol());
+            applyCautionOverride(summary, "caffeine", override.getCautionCaffeine());
+        }
 
         return DrugDetailResponse.builder()
                 .drugId(item.getItemSeq())
@@ -189,6 +191,13 @@ public class DrugDetailService {
             summary.put("caffeine", "카페인 함유 제품과 병용 시 주의하세요.");
         }
         return summary;
+    }
+
+    private void applyCautionOverride(Map<String, String> summary, String key, String overrideValue) {
+        if (!StringUtils.hasText(overrideValue)) {
+            return;
+        }
+        summary.put(key, overrideValue.trim());
     }
 
     private List<String> extractImages(String itemImage) {

--- a/src/main/resources/migration.sql
+++ b/src/main/resources/migration.sql
@@ -31,6 +31,8 @@ CREATE TABLE IF NOT EXISTS drug_manual_overrides (
     drug_id VARCHAR(32) NOT NULL COMMENT '식약처 품목기준코드',
     strength VARCHAR(255) COMMENT '수동으로 정의한 함량 정보',
     ingredients_csv VARCHAR(1000) COMMENT '쉼표로 구분된 주요 성분 목록',
+    caution_alcohol VARCHAR(1000) COMMENT '음주 관련 주의사항 수동 요약',
+    caution_caffeine VARCHAR(1000) COMMENT '카페인 관련 주의사항 수동 요약',
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '최종 수정 시각',
     PRIMARY KEY (drug_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='식약처 API 보완용 약품 정보';

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -39,6 +39,8 @@ CREATE TABLE IF NOT EXISTS drug_manual_overrides (
     drug_id VARCHAR(32) NOT NULL COMMENT '식약처 품목기준코드',
     strength VARCHAR(255) COMMENT '수동으로 정의한 함량 정보',
     ingredients_csv VARCHAR(1000) COMMENT '쉼표로 구분된 주요 성분 목록',
+    caution_alcohol VARCHAR(1000) COMMENT '음주 관련 주의사항 수동 요약',
+    caution_caffeine VARCHAR(1000) COMMENT '카페인 관련 주의사항 수동 요약',
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '최종 수정 시각',
     PRIMARY KEY (drug_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='식약처 API 보완용 약품 정보';


### PR DESCRIPTION
## 📌 변경 사항
- 음주/카페인 주의 요약을 수동으로 보강할 수 있도록 `drug_manual_overrides` 엔티티와 테이블에 `caution_alcohol`, `caution_caffeine` 컬럼 추가
- `DrugDetailService`에서 식약처 API 응답의 `cautionsSummary`에 수동 보강 데이터를 우선 적용하도록 로직 개선
- `schema.sql`, `migration.sql`에 신규 컬럼 정의 반영

## 🔍 상세 내용
- `DrugManualOverride` 엔티티에 음주·카페인 주의 문자열 필드를 추가하고 `DrugDetailService`에서 오버라이드 값이 존재할 경우 자동 요약보다 우선하여 덮어쓰도록 구현했습니다.
- 수동 값이 비어 있는 경우 기존 키워드 기반 요약이 그대로 동작하도록 해 뒤쪽 로직을 유지했습니다.
- DB 스키마 파일에 동일한 컬럼을 추가해 신규/기존 환경 모두에서 동일 스키마를 사용할 수 있게 했습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 수동 오버라이드 우선순위(수동값 > 자동 요약)가 요구사항과 맞는지 검토 부탁드립니다.
- 추가로 보강해야 할 주의 항목이 있다면 코멘트 주세요.

## 📎 참고 자료 (선택)
- 수동 테이블 생성 및 테스트 절차: 팀 공유 문서 참고 (# 수동 약품 보강 테이블 세팅 & 테스트 가이드)