### PR TITLE
[BE-#91] 약명 자동 완성 500 에러 수정

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Controller/DrugController.java
+++ b/src/main/java/com/pillmate/pillmate/Controller/DrugController.java
@@ -27,6 +27,7 @@ public class DrugController {
 
     // ---- 약 명 자동완성 ----
     // GET /api/v1/drug/suggest?q=타이&limit=10
+    @Operation(summary = "약 명 자동완성", description = "입력 중인 약명 문자열(q)에 대해 자동완성 후보 목록을 제공합니다.")
     @GetMapping("/suggest")
     public ResponseEntity<SuggestResponse> suggest(
             @RequestParam("q") String q,

--- a/src/main/java/com/pillmate/pillmate/Service/MfdsDrugInfoClient.java
+++ b/src/main/java/com/pillmate/pillmate/Service/MfdsDrugInfoClient.java
@@ -2,6 +2,7 @@ package com.pillmate.pillmate.Service;
 
 import java.net.URI;
 import java.util.List;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import org.springframework.http.ResponseEntity;
@@ -42,7 +43,8 @@ public class MfdsDrugInfoClient {
                 .queryParam("itemName", itemName)
                 .queryParam("pageNo", pageNo)
                 .queryParam("numOfRows", numOfRows)
-                .build(true)
+                .build()
+                .encode(StandardCharsets.UTF_8)
                 .toUri();
 
         try {
@@ -80,7 +82,8 @@ public class MfdsDrugInfoClient {
                 .queryParam("itemSeq", itemSeq.trim())
                 .queryParam("pageNo", 1)
                 .queryParam("numOfRows", 1)
-                .build(true)
+                .build()
+                .encode(StandardCharsets.UTF_8)
                 .toUri();
 
         try {


### PR DESCRIPTION
## 📌 변경 사항

- 식약처 자동완성 API 호출 시 한글 쿼리 파라미터가 인코딩되지 않아 500 오류가 발생하던 문제 수정
- Swagger 문서에서 `/api/v1/drug/suggest` 엔드포인트에 “약 명 자동완성” 설명 추가

## 🔍 상세 내용

- `MfdsDrugInfoClient`에서 `UriComponentsBuilder.build(true)` 대신 `build().encode(StandardCharsets.UTF_8)`을 사용해 한글 쿼리(`itemName`, `itemSeq`)를 안전하게 인코딩
- `DrugController`의 자동완성 API에 `@Operation` 메타데이터를 추가하여 Swagger UI에서 목적과 사용법을 명확히 표시

## ✅ 체크리스트

- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항

- 식약처 API 호출 시 추가로 고려해야 할 예외 케이스가 있는지 검토 부탁드립니다.

## 📎 참고 자료 (선택)

- 없음