### PR TITLE
[BE-#93] 북마크 추가 불필요한 필드 제거

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Config/SeedUserInitializer.java
+++ b/src/main/java/com/pillmate/pillmate/Config/SeedUserInitializer.java
@@ -1,0 +1,51 @@
+package com.pillmate.pillmate.Config;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pillmate.pillmate.Domain.AuthProvider;
+import com.pillmate.pillmate.Domain.User;
+import com.pillmate.pillmate.Repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "pillmate.seed-user.enabled", havingValue = "true", matchIfMissing = true)
+public class SeedUserInitializer implements ApplicationRunner {
+
+    private static final String DEFAULT_EMAIL = "user@example.com";
+    private static final String DEFAULT_PASSWORD = "Abcd1234!";
+    private static final String DEFAULT_NAME = "테스트 사용자";
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        if (userRepository.existsByEmail(DEFAULT_EMAIL)) {
+            return;
+        }
+
+        User user = User.builder()
+                .name(DEFAULT_NAME)
+                .email(DEFAULT_EMAIL)
+                .password("")
+                .termsOfService(true)
+                .privacyPolicy(true)
+                .dataUsage(false)
+                .provider(AuthProvider.LOCAL)
+                .providerId(DEFAULT_EMAIL)
+                .build();
+
+        user.encodePassword(DEFAULT_PASSWORD);
+        userRepository.save(user);
+        log.info("Seed user created: {}", DEFAULT_EMAIL);
+    }
+}
+

--- a/src/main/java/com/pillmate/pillmate/DTO/BookmarkResponse.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/BookmarkResponse.java
@@ -6,7 +6,5 @@ import lombok.*;
 @NoArgsConstructor @AllArgsConstructor @Builder
 public class BookmarkResponse {
     private String drugId;        // DRUG-000123
-    private String name;          // 약 이름
-    private String thumbnailUrl;  // 썸네일
     private String bookmarkedAt;  // ISO-8601 UTC 문자열
 }

--- a/src/main/java/com/pillmate/pillmate/Service/BookmarkService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/BookmarkService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.pillmate.pillmate.Service.dto.MfdsEasyDrugResponse.MfdsEasyDrugItem;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -23,7 +22,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BookmarkService {
 
-    private final MfdsDrugInfoClient mfdsDrugInfoClient;
     private final BookmarkRepository bookmarkRepository;
     private final DrugDetailService drugDetailService; // 외부(식약처) 조회 진입점
 
@@ -45,11 +43,8 @@ public class BookmarkService {
                                 .build()
                 ));
 
-        // 이름/썸네일은 목록/상세 조회에서 외부 API로 채우므로 여기선 null 유지
         return BookmarkResponse.builder()
                 .drugId(drugId)
-                .name(null)
-                .thumbnailUrl(null)
                 .bookmarkedAt(ISO_INSTANT.format(bookmark.getBookmarkedAt()))
                 .build();
     }

--- a/src/main/java/com/pillmate/pillmate/Util/SecurityUtil.java
+++ b/src/main/java/com/pillmate/pillmate/Util/SecurityUtil.java
@@ -2,7 +2,7 @@ package com.pillmate.pillmate.Util;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
+import com.pillmate.pillmate.Security.CustomUserDetails;
 
 /**
  * JWT 인증 기반에서 현재 로그인 사용자의 식별자(userId)를 얻는 유틸.
@@ -21,18 +21,11 @@ public final class SecurityUtil {
         Object principal = auth.getPrincipal();
 
         // 1) 커스텀 UserDetails에 getId()가 있는 경우 (예시)
-        // if (principal instanceof CustomUserDetails cud) return cud.getId();
-
-        // 2) 기본: name을 Long으로 파싱
-        String name;
-        if (principal instanceof UserDetails ud) name = ud.getUsername();
-        else name = auth.getName();
-
-        try {
-            return Long.parseLong(name);
-        } catch (NumberFormatException e) {
-            // 팀 규약에 맞게 변경 필요할 수 있음
-            throw new IllegalStateException("Cannot resolve userId from principal name=" + name);
+        if (principal instanceof CustomUserDetails cud) {
+            return cud.getId();
         }
+
+        // 2) 기타 타입은 지원하지 않음
+        throw new IllegalStateException("Cannot resolve userId from principal type=" + principal.getClass().getName());
     }
 }


### PR DESCRIPTION
## 📌 변경 사항

- 북마크 추가 API 응답에서 사용하지 않는 `name`, `thumbnailUrl` 필드를 제거해 스키마를 간결화
- `SecurityUtil`이 `CustomUserDetails`에서 직접 사용자 ID를 읽도록 수정해 인증 오류 방지
- `SeedUserInitializer`를 도입해 `user@example.com / Abcd1234!` 테스트 계정을 자동 생성 (환경 속성으로 ON/OFF 가능)

## 🔍 상세 내용

- `BookmarkResponse`와 `BookmarkService.addBookmark`에서 불필요한 필드를 제거하고 관련 null 처리 삭제
- `SecurityUtil.currentUserId()`가 principal 타입이 `CustomUserDetails`인 경우 바로 ID를 반환하도록 리팩터링
- 시드 데이터 초기화 컴포넌트 추가, 비밀번호를 `Abcd1234!`로 맞춰 자동 인서트
- 목록 조회는 기존 로직을 유지하여 상세 정보(이름/썸네일)를 외부 API로 채움

## ✅ 체크리스트

- [X] 기능이 정상적으로 동작하는지 확인했습니다.
- [X] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항

- 시드 유저 생성 로직을 운영에서 비활성화해야 하는 경우, 속성 기반 조건( `pillmate.seed-user.enabled` ) 구성이 적절한지 봐 주세요.

## 📎 참고 자료 (선택)

- 없음