### PR TITLE
[BE-#95] 복약 일정 등록 수정

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Controller/ScheduleController.java
+++ b/src/main/java/com/pillmate/pillmate/Controller/ScheduleController.java
@@ -18,6 +18,7 @@ import com.pillmate.pillmate.DTO.ScheduleResponse;
 import com.pillmate.pillmate.DTO.ScheduleUpdateRequest;
 import com.pillmate.pillmate.DTO.ScheduleUpdateResponse;
 import com.pillmate.pillmate.Service.ScheduleService;
+import com.pillmate.pillmate.Util.SecurityUtil;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -40,21 +41,23 @@ public class ScheduleController {
     @Operation(summary = "복약 일정 등록", description = "메인 캘린더에 새로운 복약 일정을 등록합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "복약 일정 등록 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-        @ApiResponse(responseCode = "409", description = "알림 시각 중복 또는 약물 충돌")
+        @ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
     @PostMapping("/schedules")
     public ResponseEntity<ScheduleCreateResponse> createSchedule(@Valid @RequestBody ScheduleRequest request) {
-        ScheduleResponse scheduleResponse = scheduleService.createSchedule(request);
+        Long userId = SecurityUtil.currentUserId();
+        ScheduleResponse scheduleResponse = scheduleService.createSchedule(userId, request);
         
         ScheduleCreateResponse response = ScheduleCreateResponse.builder()
                 .message("복약 일정이 등록되었습니다.")
                 .data(ScheduleCreateResponse.ScheduleData.builder()
                         .scheduleId(scheduleResponse.getScheduleId())
                         .drugId(scheduleResponse.getDrugId())
+                        .name(scheduleResponse.getName())
                         .dose(scheduleResponse.getDose())
-                        .alarmAt(scheduleResponse.getAlarmAt())
-                        .status(scheduleResponse.getStatus().name())
+                        .date(scheduleResponse.getDate())
+                        .plan(scheduleResponse.getPlan())
+                        .status(scheduleResponse.getStatus())
                         .startDate(scheduleResponse.getStartDate())
                         .endDate(scheduleResponse.getEndDate())
                         .build())
@@ -78,8 +81,10 @@ public class ScheduleController {
         public static class ScheduleData {
             private Long scheduleId;
             private Long drugId;
+            private String name;
             private String dose;
-            private java.time.LocalDateTime alarmAt;
+            private java.time.LocalDateTime date;
+            private String plan;
             private String status;
             private java.time.LocalDate startDate;  // 복용 시작일
             private java.time.LocalDate endDate;    // 복용 종료일

--- a/src/main/java/com/pillmate/pillmate/DTO/ScheduleRequest.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ScheduleRequest.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -19,31 +18,29 @@ import lombok.NoArgsConstructor;
 @Schema(description = "복약 일정 등록 요청")
 public class ScheduleRequest {
     
-    @NotNull(message = "사용자 ID는 필수입니다")
-    @Schema(description = "사용자 ID", example = "1", required = true)
-    private Long userId;
-    
     @NotNull(message = "약품 ID는 필수입니다")
     @Schema(description = "약품 ID", example = "12", required = true)
     private Long drugId;
+    
+    @Schema(description = "약품명", example = "타이레놀정500mg")
+    private String name;
     
     @NotBlank(message = "복용량은 필수입니다")
     @Schema(description = "복용량 또는 용법", example = "1정", required = true)
     private String dose;
     
     @NotNull(message = "알림 시각은 필수입니다")
-    @Schema(description = "알림 시각 (ISO8601 형식)", example = "2025-10-08T08:30:00", required = true)
-    private LocalDateTime alarmAt;
+    @Schema(description = "복용 예정 시각 (ISO8601 형식)", example = "2025-10-08T08:30:00", required = true)
+    private LocalDateTime date;
     
     @Schema(description = "사용자 메모", example = "식후 30분")
     private String memo;
     
-    @Valid
-    @Schema(description = "알림 설정")
-    private AlarmSettings alarm;
+    @Schema(description = "계획 상태", example = "SCHEDULED", allowableValues = {"SCHEDULED", "CANCELLED"})
+    private String plan;
     
-    @Schema(description = "반복 규칙 (RFC5545 형식)", example = "FREQ=DAILY;INTERVAL=1")
-    private String repeatRule;
+    @Schema(description = "복용 상태", example = "TAKEN", allowableValues = {"TAKEN", "MISSED"})
+    private String status;
     
     @NotNull(message = "복용 시작일은 필수입니다")
     @Schema(description = "복용 시작일", example = "2025-10-08", required = true)
@@ -53,14 +50,5 @@ public class ScheduleRequest {
     @Schema(description = "복용 종료일", example = "2025-10-15", required = true)
     private LocalDate endDate;
     
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Schema(description = "알림 설정")
-    public static class AlarmSettings {
-        @Schema(description = "알림 사용 여부", example = "true")
-        private Boolean enabled;
-    }
 }
 

--- a/src/main/java/com/pillmate/pillmate/DTO/ScheduleResponse.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ScheduleResponse.java
@@ -3,6 +3,7 @@ package com.pillmate.pillmate.DTO;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.pillmate.pillmate.Domain.Schedule;
 import com.pillmate.pillmate.Domain.ScheduleStatus;
 
@@ -25,20 +26,27 @@ public class ScheduleResponse {
     @Schema(description = "약품 ID", example = "12")
     private Long drugId;
     
-    @Schema(description = "약품명", example = "아모크라정")
-    private String drugName;
+    @Schema(description = "약품명", example = "타이레놀정500mg")
+    private String name;
     
     @Schema(description = "복용량", example = "1정")
     private String dose;
     
-    @Schema(description = "알림 시각", example = "2025-10-08T08:30:00")
-    private LocalDateTime alarmAt;
+    @Schema(description = "복용 예정 시각", example = "2025-10-08T08:30:00")
+    private LocalDateTime date;
     
     @Schema(description = "사용자 메모", example = "식후 30분")
     private String memo;
     
-    @Schema(description = "일정 상태", example = "SCHEDULED")
-    private ScheduleStatus status;
+    @Schema(description = "계획 상태", example = "SCHEDULED", allowableValues = {"SCHEDULED", "CANCELLED"})
+    private String plan;
+    
+    @Schema(description = "복용 상태", example = "TAKEN", allowableValues = {"TAKEN", "MISSED"})
+    private String status;
+    
+    @JsonIgnore
+    @Schema(description = "내부 일정 상태", hidden = true)
+    private ScheduleStatus internalStatus;
     
     @Schema(description = "복용 시작일", example = "2025-10-08")
     private LocalDate startDate;
@@ -47,14 +55,24 @@ public class ScheduleResponse {
     private LocalDate endDate;
     
     public static ScheduleResponse from(Schedule schedule) {
+        ScheduleStatus currentStatus = schedule.getStatus();
+        String resolvedPlan = currentStatus == ScheduleStatus.CANCELLED ? ScheduleStatus.CANCELLED.name() : ScheduleStatus.SCHEDULED.name();
+        String resolvedStatus = switch (currentStatus) {
+            case TAKEN -> ScheduleStatus.TAKEN.name();
+            case MISSED -> ScheduleStatus.MISSED.name();
+            default -> null;
+        };
+        
         return ScheduleResponse.builder()
                 .scheduleId(schedule.getScheduleId())
                 .drugId(schedule.getDrugId())
-                .drugName(null)  // TODO: Drug 엔티티와 조인하여 실제 약품명 조회
+                .name(schedule.getDrugName())
                 .dose(schedule.getDose())
-                .alarmAt(schedule.getAlarmAt())
+                .date(schedule.getAlarmAt())
                 .memo(schedule.getMemo())
-                .status(schedule.getStatus())
+                .plan(resolvedPlan)
+                .status(resolvedStatus)
+                .internalStatus(currentStatus)
                 .startDate(schedule.getStartDate())
                 .endDate(schedule.getEndDate())
                 .build();

--- a/src/main/java/com/pillmate/pillmate/Domain/Schedule.java
+++ b/src/main/java/com/pillmate/pillmate/Domain/Schedule.java
@@ -39,12 +39,15 @@ public class Schedule {
     
     @Column(nullable = false)
     private Long drugId;  // 약품 ID
+
+    @Column(length = 150)
+    private String drugName; // 약품명 (자동완성 결과)
     
     @Column(nullable = false, length = 100)
     private String dose;  // 복용량 또는 용법
     
     @Column(nullable = false)
-    private LocalDateTime alarmAt;  // 알림 시각
+    private LocalDateTime alarmAt;  // 복용 예정 시각
     
     @Column(columnDefinition = "TEXT")
     private String memo;  // 사용자 메모

--- a/src/main/java/com/pillmate/pillmate/Service/ScheduleService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/ScheduleService.java
@@ -11,6 +11,7 @@ import com.pillmate.pillmate.DTO.ScheduleRequest;
 import com.pillmate.pillmate.DTO.ScheduleResponse;
 import com.pillmate.pillmate.DTO.ScheduleUpdateRequest;
 import com.pillmate.pillmate.DTO.ScheduleUpdateResponse;
+import com.pillmate.pillmate.DTO.DrugDetailResponse;
 import com.pillmate.pillmate.Repository.ScheduleRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -25,40 +26,39 @@ import java.util.stream.Collectors;
 public class ScheduleService {
     
     private final ScheduleRepository scheduleRepository;
+    private final DrugDetailService drugDetailService;
     
     @Transactional
-    public ScheduleResponse createSchedule(ScheduleRequest request) {
+    public ScheduleResponse createSchedule(Long userId, ScheduleRequest request) {
         // 복용 기간 검증
         if (request.getStartDate().isAfter(request.getEndDate())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "복용 시작일은 종료일보다 이전이어야 합니다");
         }
         
         // 알림 시각이 복용 기간 내에 있는지 검증
-        if (request.getAlarmAt().toLocalDate().isBefore(request.getStartDate()) ||
-            request.getAlarmAt().toLocalDate().isAfter(request.getEndDate())) {
+        if (request.getDate().toLocalDate().isBefore(request.getStartDate()) ||
+            request.getDate().toLocalDate().isAfter(request.getEndDate())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "알림 시각은 복용 기간 내에 있어야 합니다");
         }
         
-        // 완전 중복 체크: 같은 약물, 같은 알림 시각, 같은 기간인 경우만 막음
-        // (다른 약물을 같은 시간에 복용하는 것은 허용, 같은 약물을 같은 시간에 여러 번 복용하는 것도 허용)
+        DrugDetailResponse drugDetail = fetchDrugDetailOrThrow(request.getDrugId());
+        String resolvedDrugName = resolveDrugName(request, drugDetail);
         
-        // 약물 충돌 체크 제거: 같은 약물을 여러 번 등록할 수 있도록 허용
-        // (필요시 나중에 비즈니스 로직에 따라 추가할 수 있음)
-        
+        ScheduleStatus resolvedStatus = resolveStatus(request);
+
         // 일정 생성
         Schedule schedule = Schedule.builder()
-                .userId(request.getUserId())
+                .userId(userId)
                 .drugId(request.getDrugId())
+                .drugName(resolvedDrugName)
                 .dose(request.getDose())
-                .alarmAt(request.getAlarmAt())
+                .alarmAt(request.getDate())
                 .memo(request.getMemo())
-                .alarmEnabled(request.getAlarm() != null && 
-                             request.getAlarm().getEnabled() != null && 
-                             request.getAlarm().getEnabled())
-                .repeatRule(request.getRepeatRule())
+                .alarmEnabled(Boolean.FALSE)
+                .repeatRule(null)
                 .startDate(request.getStartDate())
                 .endDate(request.getEndDate())
-                .status(ScheduleStatus.SCHEDULED)
+                .status(resolvedStatus)
                 .build();
         
         Schedule savedSchedule = scheduleRepository.save(schedule);
@@ -209,6 +209,55 @@ public class ScheduleService {
         
         scheduleRepository.delete(schedule);
         return scheduleId;
+    }
+
+    private ScheduleStatus resolveStatus(ScheduleRequest request) {
+        ScheduleStatus baseStatus = ScheduleStatus.SCHEDULED;
+
+        if (request.getPlan() != null) {
+            String planValue = request.getPlan().trim().toUpperCase();
+            if (!planValue.equals(ScheduleStatus.SCHEDULED.name()) && !planValue.equals(ScheduleStatus.CANCELLED.name())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "plan 값은 SCHEDULED 또는 CANCELLED 이어야 합니다");
+            }
+            baseStatus = ScheduleStatus.valueOf(planValue);
+        }
+
+        if (request.getStatus() != null) {
+            String statusValue = request.getStatus().trim().toUpperCase();
+            if (!statusValue.equals(ScheduleStatus.TAKEN.name()) && !statusValue.equals(ScheduleStatus.MISSED.name())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "status 값은 TAKEN 또는 MISSED 이어야 합니다");
+            }
+            if (baseStatus == ScheduleStatus.CANCELLED) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "취소된 일정은 복용 상태를 설정할 수 없습니다");
+            }
+            baseStatus = ScheduleStatus.valueOf(statusValue);
+        }
+
+        return baseStatus;
+    }
+
+    private DrugDetailResponse fetchDrugDetailOrThrow(Long drugId) {
+        try {
+            return drugDetailService.fetchDrugDetail(String.valueOf(drugId));
+        } catch (ResponseStatusException ex) {
+            if (ex.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "식약처에서 해당 약품을 찾을 수 없습니다");
+            }
+            throw ex;
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "유효하지 않은 약품 ID입니다");
+        }
+    }
+
+    private String resolveDrugName(ScheduleRequest request, DrugDetailResponse drugDetail) {
+        String officialName = drugDetail.getName();
+        if (officialName != null && !officialName.isBlank()) {
+            return officialName;
+        }
+        if (request.getName() != null && !request.getName().isBlank()) {
+            return request.getName();
+        }
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "약품명이 비어 있습니다");
     }
 }
 

--- a/src/main/resources/migration.sql
+++ b/src/main/resources/migration.sql
@@ -37,3 +37,10 @@ CREATE TABLE IF NOT EXISTS drug_manual_overrides (
     PRIMARY KEY (drug_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='식약처 API 보완용 약품 정보';
 
+-- 5. schedules 테이블 보강
+ALTER TABLE schedules 
+ADD COLUMN IF NOT EXISTS user_id BIGINT NOT NULL COMMENT '사용자 ID';
+
+ALTER TABLE schedules 
+ADD COLUMN IF NOT EXISTS drug_name VARCHAR(150) COMMENT '약품명';
+

--- a/src/main/resources/migration_mysql.sql
+++ b/src/main/resources/migration_mysql.sql
@@ -1,0 +1,35 @@
+-- 회원가입 API를 위한 users 테이블 마이그레이션 (MySQL)
+-- 기존 테이블이 있는 경우에 실행할 SQL 스크립트
+
+-- 먼저 컬럼이 존재하는지 확인 후 실행하세요
+-- 또는 아래 쿼리를 하나씩 실행하면서 에러가 나면 해당 컬럼은 이미 존재하는 것입니다
+
+-- 1. 약관 동의 필드 추가
+ALTER TABLE users 
+ADD COLUMN terms_of_service BOOLEAN NOT NULL DEFAULT FALSE COMMENT '서비스 이용약관 동의 여부';
+
+ALTER TABLE users 
+ADD COLUMN privacy_policy BOOLEAN NOT NULL DEFAULT FALSE COMMENT '개인정보 처리방침 동의 여부';
+
+ALTER TABLE users 
+ADD COLUMN data_usage BOOLEAN NOT NULL DEFAULT FALSE COMMENT '데이터 활용 동의 여부';
+
+-- 2. 생성일시, 수정일시 필드 추가
+ALTER TABLE users 
+ADD COLUMN created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '회원 생성 시각';
+
+ALTER TABLE users 
+ADD COLUMN updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '정보 최종 수정 시각';
+
+-- 3. name 컬럼 길이 변경 (50 -> 20)
+ALTER TABLE users 
+MODIFY COLUMN name VARCHAR(20) NOT NULL COMMENT '사용자 이름';
+
+-- 4. schedules 테이블 보강
+ALTER TABLE schedules 
+ADD COLUMN user_id BIGINT NOT NULL COMMENT '사용자 ID';
+
+ALTER TABLE schedules 
+ADD COLUMN drug_name VARCHAR(150) COMMENT '약품명';
+
+

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -17,7 +17,9 @@ CREATE TABLE IF NOT EXISTS users (
 
 CREATE TABLE IF NOT EXISTS schedules (
     schedule_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
     drug_id BIGINT NOT NULL COMMENT '약품 ID',
+    drug_name VARCHAR(150) COMMENT '약품명',
     dose VARCHAR(100) NOT NULL COMMENT '복용량 또는 용법',
     alarm_at DATETIME NOT NULL COMMENT '알림 시각',
     memo TEXT COMMENT '사용자 메모',


### PR DESCRIPTION
## 📌 변경 사항

- 복약 일정 생성 API를 프로젝트 명세에 맞게 재구성하고, 식약처 약품 데이터와 일관되게 동작하도록 수정했습니다.

## 🔍 상세 내용

- 요청 DTO를 `drugId`, `name`, `plan`, `status`, `date`, `startDate`, `endDate`, `memo` 중심으로 정리하고 검증 로직을 추가했습니다.  
- 컨트롤러에서 로그인 사용자 ID를 주입하고, 서비스 계층에서 `drugId`를 식약처 API로 검증한 뒤 공식 약품명을 저장하도록 변경했습니다.  
- 응답 DTO는 명세에 맞춰 `plan/status`를 분리해 제공하며 내부 상태는 숨겼습니다.  
- `drugName` 컬럼 추가 등 스키마·마이그레이션 스크립트를 업데이트했습니다.

## ✅ 체크리스트

- [x] 기능이 정상적으로 동작하는지 확인했습니다.  
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.  
  *→ API 스펙 변경으로 프런트 연동 시점에 맞춰 추가 점검 필요합니다.*

## 👀 리뷰 요청 사항

- `drugId` 검증 및 명칭 동기화 로직(`ScheduleService#createSchedule`)이 의도대로 설계됐는지 확인 부탁드립니다.  
- 스키마 변경(`user_id`, `drug_name`)이 다른 쿼리나 레포지토리에 영향을 주지 않는지 유의사항이 있다면 알려주세요.

## 📎 참고 자료 (선택)

- 없음