### PR TITLE
[BE-#109] 복약 일정 월별 조회 API 추가 및 복용 기간 필드 추가

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Controller/ScheduleController.java
+++ b/src/main/java/com/pillmate/pillmate/Controller/ScheduleController.java
@@ -57,11 +57,13 @@ public class ScheduleController {
                         .name(scheduleResponse.getName())
                         .dose(scheduleResponse.getDose())
                         .date(scheduleResponse.getDate())
+                        .alarmAt(scheduleResponse.getAlarmAt())
+                        .startDate(scheduleResponse.getStartDate())
+                        .endDate(scheduleResponse.getEndDate())
+                        .memo(scheduleResponse.getMemo())
                         .plan(scheduleResponse.getPlan())
                         .status(scheduleResponse.getStatus())
                         .alarm(scheduleResponse.getAlarm())
-                        .startDate(scheduleResponse.getStartDate())
-                        .endDate(scheduleResponse.getEndDate())
                         .build())
                 .build();
         
@@ -86,69 +88,41 @@ public class ScheduleController {
             private Long drugId;
             private String name;
             private String dose;
-            private java.time.LocalDateTime date;
+            private java.time.LocalDate date;  // 복용 날짜
+            private java.time.LocalDateTime alarmAt;  // 복용 예정 시각
+            private java.time.LocalDate startDate;  // 복용 기간 시작일 (표시용)
+            private java.time.LocalDate endDate;  // 복용 기간 종료일 (표시용)
+            private String memo;
             private String plan;
             private String status;
             private ScheduleResponse.AlarmSettings alarm;
-            private java.time.LocalDate startDate;  // 복용 시작일
-            private java.time.LocalDate endDate;    // 복용 종료일
         }
     }
     
-    @Operation(summary = "복약 일정 조회", description = "단일 날짜 또는 기간으로 복약 일정 목록을 조회합니다.")
+    @Operation(
+        summary = "복약 일정 목록 조회", 
+        description = "동일한 날짜에 등록된 모든 복약 일정(scheduleID)을 리스트로 조회합니다.\n\n" +
+                     "**단일 일정 방식**: 각 일정(scheduleID)은 하나의 날짜만 가지며, 독립적으로 관리됩니다.\n" +
+                     "동일한 날짜에 여러 일정이 등록되어 있으면 모두 리스트로 반환됩니다.\n\n" +
+                     "**응답**: 조회된 날짜와 해당 날짜의 모든 일정 목록을 반환합니다."
+    )
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "일정 조회 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청")
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (날짜 파라미터 누락 또는 잘못된 날짜 형식)")
     })
     @GetMapping("/schedules")
     public ResponseEntity<ScheduleListResponse> getSchedules(
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
-        List<ScheduleResponse> schedules;
-        
-        // date와 from/to 모두 입력된 경우 - 교집합 방식
-        if (date != null && from != null && to != null) {
-            // date가 from/to 범위 안에 있는지 확인
-            if (!date.isBefore(from) && !date.isAfter(to)) {
-                // date가 범위 안에 있으면 → date의 일정만 반환
-                schedules = scheduleService.getSchedulesByDate(date);
-            } else {
-                // date가 범위 밖이면 → 에러 반환
-                return ResponseEntity.badRequest().body(ScheduleListResponse.builder()
-                        .message("date 파라미터는 from과 to 범위 내에 있어야 합니다.")
-                        .data(ScheduleListResponse.ScheduleListData.builder()
-                                .schedules(java.util.Collections.emptyList())
-                                .build())
-                        .build());
-            }
-        } else if (from != null && to != null) {
-            // 기간 조회
-            schedules = scheduleService.getSchedulesByDateRange(from, to);
-        } else if (date != null) {
-            // 단일 날짜 조회
-            schedules = scheduleService.getSchedulesByDate(date);
-        } else if (from != null || to != null) {
-            // from 또는 to만 입력한 경우 에러
-            return ResponseEntity.badRequest().body(ScheduleListResponse.builder()
-                    .message("from과 to 파라미터는 함께 입력해야 합니다.")
-                    .data(ScheduleListResponse.ScheduleListData.builder()
-                            .schedules(java.util.Collections.emptyList())
-                            .build())
-                    .build());
-        } else {
-            // 파라미터 없음 - 400 에러
-            return ResponseEntity.badRequest().body(ScheduleListResponse.builder()
-                    .message("date 파라미터 또는 from, to 파라미터가 필요합니다.")
-                    .data(ScheduleListResponse.ScheduleListData.builder()
-                            .schedules(java.util.Collections.emptyList())
-                            .build())
-                    .build());
-        }
+            @RequestParam(required = true) 
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) 
+            @Schema(description = "조회할 날짜 (YYYY-MM-DD 형식, 필수)", example = "2025-11-12", required = true) 
+            LocalDate date) {
+        Long userId = SecurityUtil.currentUserId();
+        List<ScheduleResponse> schedules = scheduleService.getSchedulesByDate(userId, date);
         
         ScheduleListResponse response = ScheduleListResponse.builder()
                 .message("일정 조회 성공")
                 .data(ScheduleListResponse.ScheduleListData.builder()
+                        .date(date)
                         .schedules(schedules)
                         .build())
                 .build();
@@ -156,14 +130,49 @@ public class ScheduleController {
         return ResponseEntity.ok(response);
     }
     
-    @Operation(summary = "복약 일정 단일 조회", description = "일정 ID를 통해 특정 복약 일정의 상세 정보를 조회합니다.")
+    @Operation(
+        summary = "복약 일정 월별 조회", 
+        description = "특정 월에 등록된 모든 복약 일정을 날짜별로 그룹화하여 조회합니다.\n\n" +
+                     "**캘린더용 API**: 월별 캘린더 화면에서 사용하기 위한 API입니다.\n\n" +
+                     "**응답 형식**: 날짜를 키로 하고, 해당 날짜의 일정 목록을 값으로 하는 맵 형태로 반환됩니다.\n" +
+                     "예: `{ \"2025-11-01\": [...], \"2025-11-02\": [...], ... }`"
+    )
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "일정 조회 성공"),
-        @ApiResponse(responseCode = "404", description = "존재하지 않는 게시물입니다", 
-                     content = @io.swagger.v3.oas.annotations.media.Content(
-                         mediaType = "application/json",
-                         schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = com.pillmate.pillmate.DTO.ErrorResponse.class)
-                     ))
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (년도 또는 월 값이 유효하지 않음)")
+    })
+    @GetMapping("/schedules/month")
+    public ResponseEntity<ScheduleMonthResponse> getSchedulesByMonth(
+            @RequestParam(required = true) 
+            @Schema(description = "조회할 년도", example = "2025", required = true) 
+            Integer year,
+            @RequestParam(required = true) 
+            @Schema(description = "조회할 월 (1-12)", example = "11", required = true) 
+            Integer month) {
+        Long userId = SecurityUtil.currentUserId();
+        java.util.Map<java.time.LocalDate, List<ScheduleResponse>> schedulesByDate = 
+                scheduleService.getSchedulesByMonth(userId, year, month);
+        
+        ScheduleMonthResponse response = ScheduleMonthResponse.builder()
+                .message("월별 일정 조회 성공")
+                .data(ScheduleMonthResponse.ScheduleMonthData.builder()
+                        .year(year)
+                        .month(month)
+                        .schedulesByDate(schedulesByDate)
+                        .build())
+                .build();
+        
+        return ResponseEntity.ok(response);
+    }
+    
+    @Operation(
+        summary = "복약 일정 단일 조회", 
+        description = "일정 ID를 통해 특정 복약 일정을 조회합니다.\n\n" +
+                     "**단일 일정 방식**: 각 일정은 하나의 날짜만 가지며, date 파라미터가 필요 없습니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "일정 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 일정입니다")
     })
     @GetMapping("/schedules/{scheduleId}")
     public ResponseEntity<ScheduleDetailResponse> getScheduleById(@PathVariable Long scheduleId) {
@@ -181,20 +190,64 @@ public class ScheduleController {
     @lombok.Builder
     @lombok.NoArgsConstructor
     @lombok.AllArgsConstructor
+    @Schema(description = "복약 일정 목록 조회 응답")
     public static class ScheduleListResponse {
+        @Schema(description = "응답 메시지", example = "일정 조회 성공")
         private String message;
+        
+        @Schema(description = "일정 목록 데이터")
         private ScheduleListData data;
         
         @lombok.Getter
         @lombok.Builder
         @lombok.NoArgsConstructor
         @lombok.AllArgsConstructor
+        @Schema(description = "일정 목록 데이터")
         public static class ScheduleListData {
+            @Schema(description = "조회한 날짜", example = "2025-11-12")
+            private java.time.LocalDate date;
+            
+            @Schema(description = "일정 목록 (동일한 날짜에 등록된 모든 scheduleID 목록)")
             private List<ScheduleResponse> schedules;
         }
     }
     
-    @Operation(summary = "복약 일정 수정", description = "기존 일정의 세부 정보를 수정합니다.")
+    @lombok.Getter
+    @lombok.Builder
+    @lombok.NoArgsConstructor
+    @lombok.AllArgsConstructor
+    @Schema(description = "복약 일정 월별 조회 응답")
+    public static class ScheduleMonthResponse {
+        @Schema(description = "응답 메시지", example = "월별 일정 조회 성공")
+        private String message;
+        
+        @Schema(description = "월별 일정 데이터")
+        private ScheduleMonthData data;
+        
+        @lombok.Getter
+        @lombok.Builder
+        @lombok.NoArgsConstructor
+        @lombok.AllArgsConstructor
+        @Schema(description = "월별 일정 데이터")
+        public static class ScheduleMonthData {
+            @Schema(description = "조회한 년도", example = "2025")
+            private Integer year;
+            
+            @Schema(description = "조회한 월", example = "11")
+            private Integer month;
+            
+            @Schema(description = "날짜별 일정 목록 (날짜를 키로 하고, 해당 날짜의 일정 목록을 값으로 하는 맵)", 
+                     example = "{\"2025-11-01\": [...], \"2025-11-02\": [...]}")
+            private java.util.Map<java.time.LocalDate, List<ScheduleResponse>> schedulesByDate;
+        }
+    }
+    
+    @Operation(
+        summary = "복약 일정 수정", 
+        description = "기존 일정의 세부 정보를 수정합니다.\n\n" +
+                     "**단일 일정 방식**: 각 일정은 하나의 날짜만 가지며, 모든 필드를 직접 수정할 수 있습니다.\n" +
+                     "- `status`를 `TAKEN`으로 변경하면 카페인/알코올 금지 타이머가 활성화됩니다."
+    )
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "일정 수정 성공"),
         @ApiResponse(responseCode = "400", description = "잘못된 요청"),
@@ -204,7 +257,8 @@ public class ScheduleController {
     public ResponseEntity<ScheduleUpdateResponseWrapper> updateSchedule(
             @PathVariable Long scheduleId,
             @Valid @RequestBody ScheduleUpdateRequest request) {
-        ScheduleUpdateResponse updateResponse = scheduleService.updateSchedule(scheduleId, request);
+        Long userId = SecurityUtil.currentUserId();
+        ScheduleUpdateResponse updateResponse = scheduleService.updateSchedule(scheduleId, userId, request);
         
         ScheduleUpdateResponseWrapper response = ScheduleUpdateResponseWrapper.builder()
                 .message("복약 일정이 수정되었습니다.")
@@ -221,7 +275,8 @@ public class ScheduleController {
     })
     @DeleteMapping("/schedules/{scheduleId}")
     public ResponseEntity<ScheduleDeleteResponse> deleteSchedule(@PathVariable Long scheduleId) {
-        Long deletedScheduleId = scheduleService.deleteSchedule(scheduleId);
+        Long userId = SecurityUtil.currentUserId();
+        Long deletedScheduleId = scheduleService.deleteSchedule(scheduleId, userId);
         
         ScheduleDeleteResponse response = ScheduleDeleteResponse.builder()
                 .message("복약 일정이 삭제되었습니다.")

--- a/src/main/java/com/pillmate/pillmate/DTO/ScheduleRequest.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ScheduleRequest.java
@@ -30,9 +30,19 @@ public class ScheduleRequest {
     @Schema(description = "복용량 또는 용법", example = "1정", required = true)
     private String dose;
     
+    @NotNull(message = "복용 날짜는 필수입니다")
+    @Schema(description = "복용 날짜 (YYYY-MM-DD 형식)", example = "2025-10-08", required = true)
+    private LocalDate date;
+    
     @NotNull(message = "알림 시각은 필수입니다")
     @Schema(description = "복용 예정 시각 (ISO8601 형식)", example = "2025-10-08T08:30:00", required = true)
-    private LocalDateTime date;
+    private LocalDateTime alarmAt;
+    
+    @Schema(description = "복용 기간 시작일 (표시용, YYYY-MM-DD 형식)", example = "2025-10-08")
+    private LocalDate startDate;
+    
+    @Schema(description = "복용 기간 종료일 (표시용, YYYY-MM-DD 형식)", example = "2025-10-15")
+    private LocalDate endDate;
     
     @Schema(description = "사용자 메모", example = "식후 30분")
     private String memo;
@@ -40,14 +50,6 @@ public class ScheduleRequest {
     @Valid
     @Schema(description = "알림 설정")
     private AlarmSettings alarm;
-    
-    @NotNull(message = "복용 시작일은 필수입니다")
-    @Schema(description = "복용 시작일", example = "2025-10-08", required = true)
-    private LocalDate startDate;
-    
-    @NotNull(message = "복용 종료일은 필수입니다")
-    @Schema(description = "복용 종료일", example = "2025-10-15", required = true)
-    private LocalDate endDate;
     
     @Getter
     @Builder

--- a/src/main/java/com/pillmate/pillmate/DTO/ScheduleResponse.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ScheduleResponse.java
@@ -32,8 +32,17 @@ public class ScheduleResponse {
     @Schema(description = "복용량", example = "1정")
     private String dose;
     
+    @Schema(description = "복용 날짜 (YYYY-MM-DD 형식)", example = "2025-10-08")
+    private LocalDate date;
+    
     @Schema(description = "복용 예정 시각", example = "2025-10-08T08:30:00")
-    private LocalDateTime date;
+    private LocalDateTime alarmAt;
+    
+    @Schema(description = "복용 기간 시작일 (표시용)", example = "2025-10-08")
+    private LocalDate startDate;
+    
+    @Schema(description = "복용 기간 종료일 (표시용)", example = "2025-10-15")
+    private LocalDate endDate;
     
     @Schema(description = "사용자 메모", example = "식후 30분")
     private String memo;
@@ -50,12 +59,6 @@ public class ScheduleResponse {
     @JsonIgnore
     @Schema(description = "내부 일정 상태", hidden = true)
     private ScheduleStatus internalStatus;
-    
-    @Schema(description = "복용 시작일", example = "2025-10-08")
-    private LocalDate startDate;
-    
-    @Schema(description = "복용 종료일", example = "2025-10-15")
-    private LocalDate endDate;
     
     /**
      * 조회용: 현재 상태를 그대로 반환
@@ -74,7 +77,10 @@ public class ScheduleResponse {
                 .drugId(schedule.getDrugId())
                 .name(schedule.getDrugName())
                 .dose(schedule.getDose())
-                .date(schedule.getAlarmAt())
+                .date(schedule.getDate())
+                .alarmAt(schedule.getAlarmAt())
+                .startDate(schedule.getStartDate())
+                .endDate(schedule.getEndDate())
                 .memo(schedule.getMemo())
                 .plan(resolvedPlan)
                 .status(resolvedStatus)
@@ -82,8 +88,6 @@ public class ScheduleResponse {
                         .enabled(schedule.getAlarmEnabled())
                         .build())
                 .internalStatus(currentStatus)
-                .startDate(schedule.getStartDate())
-                .endDate(schedule.getEndDate())
                 .build();
     }
     
@@ -129,7 +133,10 @@ public class ScheduleResponse {
                 .drugId(schedule.getDrugId())
                 .name(schedule.getDrugName())
                 .dose(schedule.getDose())
-                .date(schedule.getAlarmAt())
+                .date(schedule.getDate())
+                .alarmAt(schedule.getAlarmAt())
+                .startDate(schedule.getStartDate())
+                .endDate(schedule.getEndDate())
                 .memo(schedule.getMemo())
                 .plan(resolvedPlan)
                 .status(resolvedStatus)
@@ -137,8 +144,6 @@ public class ScheduleResponse {
                         .enabled(schedule.getAlarmEnabled())
                         .build())
                 .internalStatus(currentStatus)
-                .startDate(schedule.getStartDate())
-                .endDate(schedule.getEndDate())
                 .build();
     }
     

--- a/src/main/java/com/pillmate/pillmate/DTO/ScheduleUpdateRequest.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ScheduleUpdateRequest.java
@@ -26,8 +26,17 @@ public class ScheduleUpdateRequest {
     @Schema(description = "복용량 또는 용법", example = "1정")
     private String dose;
     
+    @Schema(description = "복용 날짜 (YYYY-MM-DD 형식)", example = "2025-10-08")
+    private LocalDate date;
+    
     @Schema(description = "복용 예정 시각 (ISO8601 형식)", example = "2025-10-08T09:00:00")
-    private LocalDateTime date;
+    private LocalDateTime alarmAt;
+    
+    @Schema(description = "복용 기간 시작일 (표시용, YYYY-MM-DD 형식)", example = "2025-10-08")
+    private LocalDate startDate;
+    
+    @Schema(description = "복용 기간 종료일 (표시용, YYYY-MM-DD 형식)", example = "2025-10-15")
+    private LocalDate endDate;
     
     @Schema(description = "사용자 메모", example = "시간 조정")
     private String memo;
@@ -41,12 +50,6 @@ public class ScheduleUpdateRequest {
     @Valid
     @Schema(description = "알림 설정")
     private AlarmSettings alarm;
-    
-    @Schema(description = "복용 시작일", example = "2025-10-08")
-    private LocalDate startDate;
-    
-    @Schema(description = "복용 종료일", example = "2025-10-15")
-    private LocalDate endDate;
     
     @Getter
     @Builder

--- a/src/main/java/com/pillmate/pillmate/DTO/ScheduleUpdateResponse.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ScheduleUpdateResponse.java
@@ -28,8 +28,17 @@ public class ScheduleUpdateResponse {
     @Schema(description = "복용량", example = "1정")
     private String dose;
     
+    @Schema(description = "복용 날짜 (YYYY-MM-DD 형식)", example = "2025-10-08")
+    private LocalDate date;
+    
     @Schema(description = "복용 예정 시각", example = "2025-10-08T09:00:00")
-    private LocalDateTime date;
+    private LocalDateTime alarmAt;
+    
+    @Schema(description = "복용 기간 시작일 (표시용)", example = "2025-10-08")
+    private LocalDate startDate;
+    
+    @Schema(description = "복용 기간 종료일 (표시용)", example = "2025-10-15")
+    private LocalDate endDate;
     
     @Schema(description = "사용자 메모", example = "시간 조정")
     private String memo;
@@ -42,12 +51,6 @@ public class ScheduleUpdateResponse {
     
     @Schema(description = "알림 설정")
     private AlarmSettings alarm;
-    
-    @Schema(description = "복용 시작일", example = "2025-10-08")
-    private LocalDate startDate;
-    
-    @Schema(description = "복용 종료일", example = "2025-10-15")
-    private LocalDate endDate;
     
     @Schema(description = "카페인 금지 타이머 (status가 TAKEN으로 변경된 경우에만 포함)")
     private BanTimerResponse caffeineBanTimer;

--- a/src/main/java/com/pillmate/pillmate/Domain/Schedule.java
+++ b/src/main/java/com/pillmate/pillmate/Domain/Schedule.java
@@ -47,7 +47,16 @@ public class Schedule {
     private String dose;  // 복용량 또는 용법
     
     @Column(nullable = false)
+    private LocalDate date;  // 복용 날짜 (단일 날짜)
+    
+    @Column(nullable = false)
     private LocalDateTime alarmAt;  // 복용 예정 시각
+    
+    @Column
+    private LocalDate startDate;  // 복용 기간 시작일 (표시용)
+    
+    @Column
+    private LocalDate endDate;  // 복용 기간 종료일 (표시용)
     
     @Column(columnDefinition = "TEXT")
     private String memo;  // 사용자 메모
@@ -57,12 +66,6 @@ public class Schedule {
     
     @Column(length = 500)
     private String repeatRule;  // 반복 규칙 (RFC5545 형식)
-    
-    @Column(nullable = false)
-    private LocalDate startDate;  // 복용 시작일
-    
-    @Column(nullable = false)
-    private LocalDate endDate;  // 복용 종료일
     
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "VARCHAR(20) DEFAULT 'SCHEDULED'")
@@ -95,6 +98,10 @@ public class Schedule {
     
     public void updateAlarmEnabled(Boolean alarmEnabled) {
         this.alarmEnabled = alarmEnabled;
+    }
+    
+    public void updateDate(LocalDate date) {
+        this.date = date;
     }
     
     public void updateStartDate(LocalDate startDate) {

--- a/src/main/java/com/pillmate/pillmate/Repository/ScheduleRepository.java
+++ b/src/main/java/com/pillmate/pillmate/Repository/ScheduleRepository.java
@@ -13,32 +13,31 @@ import com.pillmate.pillmate.Domain.Schedule;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
-    // 같은 약물과 같은 알림 시각에 존재하는 일정 조회 (완전 중복 체크용)
+    // 같은 약물과 같은 날짜, 같은 알림 시각에 존재하는 일정 조회 (완전 중복 체크용)
     @Query("SELECT s FROM Schedule s WHERE s.drugId = :drugId " +
+           "AND s.date = :date " +
            "AND s.alarmAt = :alarmAt")
-    List<Schedule> findByDrugIdAndAlarmAt(@Param("drugId") Long drugId, 
-                                           @Param("alarmAt") LocalDateTime alarmAt);
+    List<Schedule> findByDrugIdAndDateAndAlarmAt(@Param("drugId") Long drugId, 
+                                                  @Param("date") LocalDate date,
+                                                  @Param("alarmAt") LocalDateTime alarmAt);
     
-    // 특정 기간에 약물이 이미 등록되어 있는지 확인 (약물 충돌 체크용)
-    @Query("SELECT s FROM Schedule s WHERE s.drugId = :drugId " +
-           "AND ((s.startDate <= :endDate AND s.endDate >= :startDate))")
-    List<Schedule> findOverlappingSchedules(@Param("drugId") Long drugId, 
-                                             @Param("startDate") LocalDate startDate,
-                                             @Param("endDate") LocalDate endDate);
+    // 특정 날짜의 일정 조회
+    @Query("SELECT s FROM Schedule s WHERE s.date = :date ORDER BY s.alarmAt")
+    List<Schedule> findByDate(@Param("date") LocalDate date);
     
     // 특정 기간의 일정 조회
-    @Query("SELECT s FROM Schedule s WHERE s.startDate <= :endDate AND s.endDate >= :startDate ORDER BY s.alarmAt")
+    @Query("SELECT s FROM Schedule s WHERE s.date >= :startDate AND s.date <= :endDate ORDER BY s.date, s.alarmAt")
     List<Schedule> findByDateRange(@Param("startDate") LocalDate startDate, 
                                     @Param("endDate") LocalDate endDate);
-    
-    // 특정 날짜의 일정 조회 (해당 날짜가 startDate와 endDate 사이에 있는 일정)
-    @Query("SELECT s FROM Schedule s WHERE s.startDate <= :date AND s.endDate >= :date ORDER BY s.alarmAt")
-    List<Schedule> findByDate(@Param("date") LocalDate date);
     
     // 사용자별 일정 개수 조회
     int countByUserId(Long userId);
     
     // 사용자, 약물, 상태로 일정 조회
     List<Schedule> findByUserIdAndDrugIdAndStatus(Long userId, Long drugId, com.pillmate.pillmate.Domain.ScheduleStatus status);
+    
+    // 사용자, 날짜로 일정 조회
+    @Query("SELECT s FROM Schedule s WHERE s.userId = :userId AND s.date = :date ORDER BY s.alarmAt")
+    List<Schedule> findByUserIdAndDate(@Param("userId") Long userId, @Param("date") LocalDate date);
 
 }

--- a/src/main/java/com/pillmate/pillmate/Service/ScheduleService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/ScheduleService.java
@@ -37,15 +37,9 @@ public class ScheduleService {
     
     @Transactional
     public ScheduleResponse createSchedule(Long userId, ScheduleRequest request) {
-        // 복용 기간 검증
-        if (request.getStartDate().isAfter(request.getEndDate())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "복용 시작일은 종료일보다 이전이어야 합니다");
-        }
-        
-        // 알림 시각이 복용 기간 내에 있는지 검증
-        if (request.getDate().toLocalDate().isBefore(request.getStartDate()) ||
-            request.getDate().toLocalDate().isAfter(request.getEndDate())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "알림 시각은 복용 기간 내에 있어야 합니다");
+        // 복용 날짜와 알림 시각 검증
+        if (request.getAlarmAt() != null && !request.getDate().equals(request.getAlarmAt().toLocalDate())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "복용 날짜와 알림 시각의 날짜가 일치해야 합니다");
         }
         
         DrugDetailResponse drugDetail = fetchDrugDetailOrThrow(request.getDrugId());
@@ -55,18 +49,30 @@ public class ScheduleService {
         // 등록 시에는 항상 SCHEDULED로 저장 (기본값)
         ScheduleStatus resolvedStatus = ScheduleStatus.SCHEDULED;
 
-        // 일정 생성
+        // 복용 기간 검증 (startDate, endDate가 있으면)
+        if (request.getStartDate() != null && request.getEndDate() != null) {
+            if (request.getStartDate().isAfter(request.getEndDate())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "복용 시작일은 종료일보다 이전이어야 합니다");
+            }
+            // date가 기간 내에 있는지 검증 (선택사항)
+            if (request.getDate().isBefore(request.getStartDate()) || request.getDate().isAfter(request.getEndDate())) {
+                // 경고만 하고 계속 진행 (date가 기간 밖에 있어도 허용)
+            }
+        }
+        
+        // 일정 생성 (단일 날짜, 복용 기간은 표시용)
         Schedule schedule = Schedule.builder()
                 .userId(userId)
                 .drugId(request.getDrugId())
                 .drugName(resolvedDrugName)
                 .dose(request.getDose())
-                .alarmAt(request.getDate())
+                .date(request.getDate())
+                .alarmAt(request.getAlarmAt())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
                 .memo(request.getMemo())
                 .alarmEnabled(alarmEnabled)
                 .repeatRule(null)
-                .startDate(request.getStartDate())
-                .endDate(request.getEndDate())
                 .status(resolvedStatus)
                 .build();
         
@@ -83,18 +89,19 @@ public class ScheduleService {
      */
     public ScheduleResponse getScheduleById(Long scheduleId) {
         Schedule schedule = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 게시물입니다"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 일정입니다"));
         
         return ScheduleResponse.from(schedule);
     }
     
     /**
      * 특정 날짜의 일정 조회
+     * @param userId 사용자 ID
      * @param date 조회할 날짜 (YYYY-MM-DD 형식)
      * @return 해당 날짜의 일정 목록
      */
-    public List<ScheduleResponse> getSchedulesByDate(LocalDate date) {
-        List<Schedule> schedules = scheduleRepository.findByDate(date);
+    public List<ScheduleResponse> getSchedulesByDate(Long userId, LocalDate date) {
+        List<Schedule> schedules = scheduleRepository.findByUserIdAndDate(userId, date);
         return schedules.stream()
                 .map(ScheduleResponse::from)
                 .collect(Collectors.toList());
@@ -102,31 +109,67 @@ public class ScheduleService {
     
     /**
      * 특정 기간의 일정 조회
+     * @param userId 사용자 ID
      * @param from 시작 날짜 (YYYY-MM-DD 형식)
      * @param to 종료 날짜 (YYYY-MM-DD 형식)
      * @return 해당 기간의 일정 목록
      */
-    public List<ScheduleResponse> getSchedulesByDateRange(LocalDate from, LocalDate to) {
+    public List<ScheduleResponse> getSchedulesByDateRange(Long userId, LocalDate from, LocalDate to) {
         if (from.isAfter(to)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "시작일은 종료일보다 이전이어야 합니다");
         }
         
         List<Schedule> schedules = scheduleRepository.findByDateRange(from, to);
-        return schedules.stream()
+        // 사용자 필터링
+        List<Schedule> userSchedules = schedules.stream()
+                .filter(s -> s.getUserId().equals(userId))
+                .collect(Collectors.toList());
+        
+        return userSchedules.stream()
                 .map(ScheduleResponse::from)
                 .collect(Collectors.toList());
     }
     
     /**
+     * 특정 월의 일정 조회 (날짜별로 그룹화)
+     * @param userId 사용자 ID
+     * @param year 년도 (예: 2025)
+     * @param month 월 (1-12)
+     * @return 해당 월의 일정 목록 (날짜별로 그룹화)
+     */
+    public java.util.Map<LocalDate, List<ScheduleResponse>> getSchedulesByMonth(Long userId, int year, int month) {
+        if (month < 1 || month > 12) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "월은 1부터 12 사이의 값이어야 합니다");
+        }
+        
+        // 해당 월의 첫 날과 마지막 날 계산
+        LocalDate firstDayOfMonth = LocalDate.of(year, month, 1);
+        LocalDate lastDayOfMonth = firstDayOfMonth.withDayOfMonth(firstDayOfMonth.lengthOfMonth());
+        
+        // 해당 월의 모든 일정 조회
+        List<ScheduleResponse> schedules = getSchedulesByDateRange(userId, firstDayOfMonth, lastDayOfMonth);
+        
+        // 날짜별로 그룹화
+        return schedules.stream()
+                .collect(Collectors.groupingBy(ScheduleResponse::getDate));
+    }
+    
+    /**
      * 일정 수정
      * @param scheduleId 일정 ID
+     * @param userId 사용자 ID
      * @param request 수정 요청 데이터
      * @return 수정된 일정 정보
      */
     @Transactional
-    public ScheduleUpdateResponse updateSchedule(Long scheduleId, ScheduleUpdateRequest request) {
+    public ScheduleUpdateResponse updateSchedule(Long scheduleId, Long userId, ScheduleUpdateRequest request) {
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다"));
+        
+        // 사용자 검증
+        if (!schedule.getUserId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 일정을 수정할 권한이 없습니다");
+        }
         
         // 약품 변경 처리 (drugId가 제공되면 새로운 약품으로 변경)
         Long targetDrugId = request.getDrugId() != null ? request.getDrugId() : schedule.getDrugId();
@@ -147,34 +190,35 @@ public class ScheduleService {
             schedule.setDrugName(officialName);
         }
         
-        // 복용 기간 검증 및 수정
-        if (request.getStartDate() != null || request.getEndDate() != null) {
-            LocalDate newStartDate = request.getStartDate() != null ? request.getStartDate() : schedule.getStartDate();
-            LocalDate newEndDate = request.getEndDate() != null ? request.getEndDate() : schedule.getEndDate();
-            
-            if (newStartDate.isAfter(newEndDate)) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "복용 시작일은 종료일보다 이전이어야 합니다");
-            }
-            
-            if (request.getStartDate() != null && !request.getStartDate().equals(schedule.getStartDate())) {
-                schedule.updateStartDate(request.getStartDate());
-            }
-            
-            if (request.getEndDate() != null && !request.getEndDate().equals(schedule.getEndDate())) {
-                schedule.updateEndDate(request.getEndDate());
-            }
+        // 복용 날짜 수정
+        if (request.getDate() != null && !request.getDate().equals(schedule.getDate())) {
+            schedule.updateDate(request.getDate());
         }
         
-        // 복용 예정 시각 수정 (date 필드)
-        if (request.getDate() != null && !request.getDate().equals(schedule.getAlarmAt())) {
-            LocalDate alarmDate = request.getDate().toLocalDate();
-            LocalDate currentStartDate = request.getStartDate() != null ? request.getStartDate() : schedule.getStartDate();
-            LocalDate currentEndDate = request.getEndDate() != null ? request.getEndDate() : schedule.getEndDate();
-            
-            if (alarmDate.isBefore(currentStartDate) || alarmDate.isAfter(currentEndDate)) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "알림 시각은 복용 기간 내에 있어야 합니다");
+        // 복용 예정 시각 수정
+        if (request.getAlarmAt() != null && !request.getAlarmAt().equals(schedule.getAlarmAt())) {
+            // 날짜와 알림 시각의 날짜가 일치하는지 검증
+            LocalDate scheduleDate = request.getDate() != null ? request.getDate() : schedule.getDate();
+            if (!scheduleDate.equals(request.getAlarmAt().toLocalDate())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "복용 날짜와 알림 시각의 날짜가 일치해야 합니다");
             }
-            schedule.updateAlarmAt(request.getDate());
+            schedule.updateAlarmAt(request.getAlarmAt());
+        }
+        
+        // 복용 기간 수정 (표시용)
+        if (request.getStartDate() != null && !request.getStartDate().equals(schedule.getStartDate())) {
+            schedule.updateStartDate(request.getStartDate());
+        }
+        
+        if (request.getEndDate() != null && !request.getEndDate().equals(schedule.getEndDate())) {
+            schedule.updateEndDate(request.getEndDate());
+        }
+        
+        // 복용 기간 검증 (startDate, endDate가 모두 있으면)
+        if (request.getStartDate() != null && request.getEndDate() != null) {
+            if (request.getStartDate().isAfter(request.getEndDate())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "복용 시작일은 종료일보다 이전이어야 합니다");
+            }
         }
         
         // 복용량 수정
@@ -187,16 +231,65 @@ public class ScheduleService {
             schedule.updateMemo(request.getMemo());
         }
         
-        // 상태 수정 (plan과 status 분리 처리)
-        ScheduleStatus previousStatus = schedule.getStatus();
-        ScheduleStatus resolvedStatus = resolveUpdateStatus(request, schedule.getStatus());
+        // 상태 수정 및 금지 타이머 계산
+        BanTimerResponse caffeineBanTimer = null;
+        BanTimerResponse alcoholBanTimer = null;
         
-        // 요청에 status="TAKEN"이 명시적으로 포함되어 있는지 확인
-        boolean statusExplicitlySetToTaken = request.getStatus() != null && 
-                                              request.getStatus().trim().toUpperCase().equals(ScheduleStatus.TAKEN.name());
+        if (request.getStatus() != null) {
+            String statusValue = request.getStatus().trim().toUpperCase();
+            ScheduleStatus previousStatus = schedule.getStatus();
+            ScheduleStatus newStatus = resolveStatus(statusValue);
+            
+            // 상태 변경
+            schedule.updateStatus(newStatus);
+            
+            // TAKEN 상태로 변경된 경우 금지 타이머 계산
+            if (newStatus == ScheduleStatus.TAKEN && previousStatus != ScheduleStatus.TAKEN) {
+                // 복용 기록 생성 (복용 완료 시각은 현재 시각 사용)
+                LocalDateTime takenAt = LocalDateTime.now();
+                
+                // 중복 방지: 이미 복용 기록이 있는지 확인
+                List<MedicationIntake> existingIntakes = medicationIntakeRepository.findByScheduleId(scheduleId);
+                if (existingIntakes.isEmpty()) {
+                    MedicationIntake medicationIntake = MedicationIntake.builder()
+                            .scheduleId(scheduleId)
+                            .drugId(schedule.getDrugId())
+                            .takenAt(takenAt)
+                            .build();
+                    medicationIntakeRepository.save(medicationIntake);
+                } else {
+                    // 이미 기록이 있으면 가장 최근 기록 사용
+                    takenAt = existingIntakes.stream()
+                            .map(MedicationIntake::getTakenAt)
+                            .max(LocalDateTime::compareTo)
+                            .orElse(LocalDateTime.now());
+                }
+                
+                // 금지 타이머 계산 (카페인, 알코올)
+                List<BanTimerResponse> banTimers = medicationIntakeService.calculateBanTimersInternal(takenAt, schedule.getDrugId());
+                
+                // 카페인과 알코올 타이머 분리
+                for (BanTimerResponse timer : banTimers) {
+                    if ("caffeine".equals(timer.getType())) {
+                        caffeineBanTimer = timer;
+                    } else if ("alcohol".equals(timer.getType())) {
+                        alcoholBanTimer = timer;
+                    }
+                }
+            }
+        }
         
-        if (!resolvedStatus.equals(schedule.getStatus())) {
-            schedule.updateStatus(resolvedStatus);
+        // plan 처리 (CANCELLED 상태로 변경)
+        if (request.getPlan() != null) {
+            String planValue = request.getPlan().trim().toUpperCase();
+            if ("CANCELLED".equals(planValue)) {
+                schedule.updateStatus(ScheduleStatus.CANCELLED);
+            } else if ("SCHEDULED".equals(planValue)) {
+                // CANCELLED에서 SCHEDULED로 복구 (단, status가 TAKEN/MISSED가 아니면)
+                if (schedule.getStatus() == ScheduleStatus.CANCELLED) {
+                    schedule.updateStatus(ScheduleStatus.SCHEDULED);
+                }
+            }
         }
         
         // 알림 설정 수정
@@ -209,47 +302,25 @@ public class ScheduleService {
         
         Schedule savedSchedule = scheduleRepository.save(schedule);
         
-        // status="TAKEN"으로 명시적으로 설정된 경우 MedicationIntake 기록 생성 및 금지 타이머 계산
-        BanTimerResponse caffeineBanTimer = null;
-        BanTimerResponse alcoholBanTimer = null;
-        
-        if (statusExplicitlySetToTaken && resolvedStatus.equals(ScheduleStatus.TAKEN)) {
-            // 복용 기록 생성 (복용 완료 시각은 현재 시각 사용)
-            LocalDateTime takenAt = LocalDateTime.now();
-            
-            MedicationIntake medicationIntake = MedicationIntake.builder()
-                    .scheduleId(savedSchedule.getScheduleId())
-                    .drugId(savedSchedule.getDrugId())
-                    .takenAt(takenAt)
-                    .build();
-            medicationIntakeRepository.save(medicationIntake);
-            
-            // 금지 타이머 계산 (카페인, 알코올)
-            List<BanTimerResponse> banTimers = medicationIntakeService.calculateBanTimersInternal(takenAt, savedSchedule.getDrugId());
-            
-            // 카페인과 알코올 타이머 분리
-            for (BanTimerResponse timer : banTimers) {
-                if ("caffeine".equals(timer.getType())) {
-                    caffeineBanTimer = timer;
-                } else if ("alcohol".equals(timer.getType())) {
-                    alcoholBanTimer = timer;
-                }
-            }
-        }
-        
-        // 응답을 ScheduleResponse.from()과 동일한 구조로 변환
+        // 응답 생성
         return buildUpdateResponse(savedSchedule, caffeineBanTimer, alcoholBanTimer);
     }
     
     /**
      * 일정 삭제
      * @param scheduleId 일정 ID
+     * @param userId 사용자 ID
      * @return 삭제된 일정 ID
      */
     @Transactional
-    public Long deleteSchedule(Long scheduleId) {
+    public Long deleteSchedule(Long scheduleId, Long userId) {
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다"));
+        
+        // 사용자 검증
+        if (!schedule.getUserId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 일정을 삭제할 권한이 없습니다");
+        }
         
         scheduleRepository.delete(schedule);
         return scheduleId;
@@ -297,39 +368,16 @@ public class ScheduleService {
         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "약품명이 비어 있습니다");
     }
     
-    /**
-     * 수정 요청의 plan과 status를 기존 상태와 병합하여 최종 상태 결정
-     */
-    private ScheduleStatus resolveUpdateStatus(ScheduleUpdateRequest request, ScheduleStatus currentStatus) {
-        ScheduleStatus baseStatus = currentStatus;
-        
-        // plan 처리 (SCHEDULED 또는 CANCELLED)
-        if (request.getPlan() != null) {
-            String planValue = request.getPlan().trim().toUpperCase();
-            if (!planValue.equals(ScheduleStatus.SCHEDULED.name()) && !planValue.equals(ScheduleStatus.CANCELLED.name())) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "plan 값은 SCHEDULED 또는 CANCELLED 이어야 합니다");
-            }
-            baseStatus = ScheduleStatus.valueOf(planValue);
+    private ScheduleStatus resolveStatus(String statusValue) {
+        try {
+            return ScheduleStatus.valueOf(statusValue);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "유효하지 않은 상태 값입니다: " + statusValue);
         }
-        
-        // status 처리 (TAKEN 또는 MISSED)
-        if (request.getStatus() != null) {
-            String statusValue = request.getStatus().trim().toUpperCase();
-            if (!statusValue.equals(ScheduleStatus.TAKEN.name()) && !statusValue.equals(ScheduleStatus.MISSED.name())) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "status 값은 TAKEN 또는 MISSED 이어야 합니다");
-            }
-            // CANCELLED 상태에서 바로 TAKEN/MISSED로 변경 불가 (plan을 SCHEDULED로 먼저 변경해야 함)
-            if (baseStatus == ScheduleStatus.CANCELLED) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "취소된 일정은 복용 상태를 설정할 수 없습니다. 먼저 plan을 SCHEDULED로 변경해주세요");
-            }
-            baseStatus = ScheduleStatus.valueOf(statusValue);
-        }
-        
-        return baseStatus;
     }
     
     /**
-     * Schedule 엔티티를 ScheduleUpdateResponse로 변환 (ScheduleResponse.from()과 동일한 구조)
+     * Schedule 엔티티를 ScheduleUpdateResponse로 변환
      */
     private ScheduleUpdateResponse buildUpdateResponse(Schedule schedule, BanTimerResponse caffeineBanTimer, BanTimerResponse alcoholBanTimer) {
         ScheduleStatus currentStatus = schedule.getStatus();
@@ -345,15 +393,16 @@ public class ScheduleService {
                 .drugId(schedule.getDrugId())
                 .name(schedule.getDrugName())
                 .dose(schedule.getDose())
-                .date(schedule.getAlarmAt())
+                .date(schedule.getDate())
+                .alarmAt(schedule.getAlarmAt())
+                .startDate(schedule.getStartDate())
+                .endDate(schedule.getEndDate())
                 .memo(schedule.getMemo())
                 .plan(resolvedPlan)
                 .status(resolvedStatus)
                 .alarm(ScheduleUpdateResponse.AlarmSettings.builder()
                         .enabled(schedule.getAlarmEnabled())
                         .build())
-                .startDate(schedule.getStartDate())
-                .endDate(schedule.getEndDate())
                 .caffeineBanTimer(caffeineBanTimer)
                 .alcoholBanTimer(alcoholBanTimer)
                 .build();

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS users (
     INDEX idx_email (email)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 정보 테이블';
 
--- schedules 테이블 생성 스크립트 (캘린더 복약 일정)
+-- schedules 테이블 생성 스크립트 (캘린더 복약 일정 - 단일 일정 방식)
 
 CREATE TABLE IF NOT EXISTS schedules (
     schedule_id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -21,20 +21,24 @@ CREATE TABLE IF NOT EXISTS schedules (
     drug_id BIGINT NOT NULL COMMENT '약품 ID',
     drug_name VARCHAR(150) COMMENT '약품명',
     dose VARCHAR(100) NOT NULL COMMENT '복용량 또는 용법',
-    alarm_at DATETIME NOT NULL COMMENT '알림 시각',
+    date DATE NOT NULL COMMENT '복용 날짜 (단일 날짜)',
+    alarm_at DATETIME NOT NULL COMMENT '복용 예정 시각',
+    start_date DATE NULL COMMENT '복용 기간 시작일 (표시용)',
+    end_date DATE NULL COMMENT '복용 기간 종료일 (표시용)',
     memo TEXT COMMENT '사용자 메모',
     alarm_enabled BOOLEAN NOT NULL DEFAULT FALSE COMMENT '알림 사용 여부',
     repeat_rule VARCHAR(500) COMMENT '반복 규칙 (RFC5545 형식)',
-    start_date DATE NOT NULL COMMENT '복용 시작일',
-    end_date DATE NOT NULL COMMENT '복용 종료일',
-    status VARCHAR(20) NOT NULL DEFAULT 'SCHEDULED' COMMENT '일정 상태 (SCHEDULED, COMPLETED, MISSED, CANCELLED)',
+    status VARCHAR(20) NOT NULL DEFAULT 'SCHEDULED' COMMENT '일정 상태 (SCHEDULED, TAKEN, MISSED, CANCELLED)',
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '일정 생성 시각',
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '일정 수정 시각',
     INDEX idx_drug_id (drug_id),
+    INDEX idx_date (date),
+    INDEX idx_user_date (user_id, date),
     INDEX idx_alarm_at (alarm_at),
-    INDEX idx_date_range (start_date, end_date),
-    INDEX idx_status (status)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='캘린더 복약 일정 테이블';
+    INDEX idx_status (status),
+    INDEX idx_start_date (start_date),
+    INDEX idx_end_date (end_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='캘린더 복약 일정 테이블 (단일 일정 방식)';
 
 -- 약품 수동 보강 데이터를 저장하는 테이블
 CREATE TABLE IF NOT EXISTS drug_manual_overrides (


### PR DESCRIPTION
# 복약 일정 월별 조회 API 추가 및 복용 기간 필드 추가

## 📝 요약

- Schedule 엔티티에 startDate, endDate 필드 추가 (표시용)
- 월별 조회 API 추가: GET /api/v1/main/calendar/schedules/month
- 단일 날짜 조회 API로 변경: GET /api/v1/main/calendar/schedules?date=YYYY-MM-DD
- 모든 로직은 단일 scheduleID 기준으로 동작
- 복용 기간(startDate, endDate)은 UI 표시용으로만 사용

## 📌 변경 사항

### 1. Schedule 엔티티 수정
- `startDate`, `endDate` 필드 추가 (표시용, nullable)
- `updateStartDate()`, `updateEndDate()` 메서드 추가

### 2. DTO 수정
- `ScheduleRequest`: `startDate`, `endDate` 필드 추가 (선택)
- `ScheduleResponse`: `startDate`, `endDate` 필드 추가
- `ScheduleUpdateRequest`: `startDate`, `endDate` 필드 추가 (선택)
- `ScheduleUpdateResponse`: `startDate`, `endDate` 필드 추가

### 3. API 엔드포인트 추가/수정
- **월별 조회 API 추가**: `GET /api/v1/main/calendar/schedules/month?year=2025&month=11`
  - 특정 월의 모든 일정을 날짜별로 그룹화하여 반환
  - 캘린더 화면에서 사용하기 위한 API
- **단일 날짜 조회 API 수정**: `GET /api/v1/main/calendar/schedules?date=2025-11-12`
  - 기간 조회(`from`, `to`) 기능 제거
  - 단일 날짜 조회만 지원하도록 변경

### 4. Service 로직 수정
- `ScheduleService.createSchedule()`: `startDate`, `endDate` 저장 로직 추가
- `ScheduleService.updateSchedule()`: `startDate`, `endDate` 수정 로직 추가
- `ScheduleService.getSchedulesByMonth()`: 월별 조회 메서드 추가
  - 해당 월의 첫 날부터 마지막 날까지의 모든 일정 조회
  - 날짜별로 그룹화하여 반환

### 5. 데이터베이스 스키마 수정
- `schedules` 테이블에 `start_date`, `end_date` 컬럼 추가 (nullable)
- 인덱스 추가: `idx_start_date`, `idx_end_date`

## 🔍 상세 내용

### 단일 일정 방식 유지
- 각 `scheduleID`는 하나의 날짜(`date`)만 가짐
- 모든 등록, 수정, 삭제, 조회 로직은 단일 `scheduleID` 기준으로 동작
- 복용 기간(`startDate`, `endDate`)은 UI 표시용 메타데이터로만 사용

### 월별 조회 API 동작 방식
1. `year`와 `month` 파라미터로 해당 월의 첫 날과 마지막 날 계산
2. 해당 기간의 모든 일정 조회
3. 날짜별로 그룹화하여 반환
4. 응답 형식: `{ "2025-11-01": [...], "2025-11-02": [...], ... }`

### 복용 기간 필드 동작
- **목적**: 이 약을 언제부터 언제까지 복용하는지 UI에 표시
- **저장**: DB에 저장되지만 로직에는 사용하지 않음
- **예시**: 
  - `date = 2025-11-12` (실제 복용 날짜)
  - `startDate = 2025-11-10`, `endDate = 2025-11-15` (표시용)
  - UI: "2025-11-10 ~ 2025-11-15" 텍스트 표시

### 응답 형식

#### 단일 날짜 조회 응답
{
  "message": "일정 조회 성공",
  "data": {
    "date": "2025-11-12",
    "schedules": [
      {
        "scheduleId": 101,
        "drugId": 12,
        "name": "타이레놀정500mg",
        "date": "2025-11-12",
        "startDate": "2025-11-10",
        "endDate": "2025-11-15",
        ...
      }
    ]
  }
}
#### 월별 조회 응답
{
  "message": "월별 일정 조회 성공",
  "data": {
    "year": 2025,
    "month": 11,
    "schedulesByDate": {
      "2025-11-01": [...],
      "2025-11-02": [...],
      ...
    }
  }
}## ✅ 체크리스트

- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 단일 일정 방식으로 동작하는지 확인했습니다.
- [x] 월별 조회 API가 정상적으로 동작하는지 확인했습니다.
- [x] 복용 기간 필드가 표시용으로만 사용되는지 확인했습니다.
- [x] 데이터베이스 마이그레이션 스크립트 작성했습니다.

## 👀 리뷰 요청 사항

### 확인이 필요한 부분
1. **데이터베이스 마이그레이션**: `start_date`, `end_date` 컬럼 추가가 필요합니다.
   - 마이그레이션 SQL: `migration_add_start_end_date.sql` 참고
   - 또는 `schema.sql`의 변경 사항을 적용

2. **API 응답 형식**: 월별 조회 API의 응답이 `Map<LocalDate, List<ScheduleResponse>>` 형식인데, JSON 직렬화 시 키가 문자열로 변환됩니다.
   - 프론트엔드에서 `"2025-11-01"` 형식의 문자열 키로 접근해야 합니다.

3. **복용 기간 검증**: `startDate`와 `endDate`가 모두 제공된 경우, `startDate <= endDate` 검증을 수행합니다.
   - 단, `date` 필드가 기간 밖에 있어도 허용됩니다 (표시용이므로).

### 주의사항
- `application.yml`은 환경 설정 파일이므로 커밋하지 않았습니다.
- 마이그레이션 SQL 파일들은 개발 과정에서 생성된 파일이므로 필요시만 추가하세요.

## 📎 참고 자료

### 관련 파일
- `src/main/java/com/pillmate/pillmate/Domain/Schedule.java`
- `src/main/java/com/pillmate/pillmate/Service/ScheduleService.java`
- `src/main/java/com/pillmate/pillmate/Controller/ScheduleController.java`
- `src/main/resources/schema.sql`

### API 엔드포인트
- **단일 날짜 조회**: `GET /api/v1/main/calendar/schedules?date=YYYY-MM-DD`
- **월별 조회**: `GET /api/v1/main/calendar/schedules/month?year=YYYY&month=MM`
- **단일 일정 조회**: `GET /api/v1/main/calendar/schedules/{scheduleId}`
- **일정 등록**: `POST /api/v1/main/calendar/schedules`
- **일정 수정**: `PUT /api/v1/main/calendar/schedules/{scheduleId}`
- **일정 삭제**: `DELETE /api/v1/main/calendar/schedules/{scheduleId}`

### 테스트 시나리오
1. 단일 날짜 조회 API로 특정 날짜의 일정 목록 조회
2. 월별 조회 API로 특정 월의 모든 일정 조회 (날짜별로 그룹화)
3. 일정 등록 시 `startDate`, `endDate` 포함하여 등록
4. 일정 수정 시 `startDate`, `endDate` 수정
5. 응답에서 `startDate`, `endDate`가 정상적으로 반환되는지 확인