### PR TITLE
[BE-#112] 대시보드 진행률 API 개선 및 자동 MISSED 상태 변경 기능 추가

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Controller/DashboardController.java
+++ b/src/main/java/com/pillmate/pillmate/Controller/DashboardController.java
@@ -2,8 +2,11 @@ package com.pillmate.pillmate.Controller;
 
 import com.pillmate.pillmate.DTO.DashboardProgressResponse;
 import com.pillmate.pillmate.Service.DashboardService;
+import com.pillmate.pillmate.Util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,16 +25,28 @@ public class DashboardController {
 
 	@Operation(
 		summary = "대시보드 진행률 조회",
-		description = "userId는 필수, year/month 주면 그 달 기준으로 계산. 안 주면 이번 달 기준."
+		description = "현재 로그인한 사용자의 대시보드 진행률을 조회합니다.\n\n" +
+					"year/month 파라미터가 제공되면 해당 월 기준으로 계산하고, 없으면 현재 월 기준으로 계산합니다.\n\n" +
+					"**계산 방식**:\n" +
+					"- totalPlanned: 해당 기간 내 등록된 일정 개수 (CANCELLED 상태 제외, SCHEDULED/TAKEN/MISSED 포함)\n" +
+					"- completed: TAKEN 상태인 일정 개수 (복용 완료)\n" +
+					"- missed: MISSED 상태인 일정 개수 (명시적으로 누락으로 표시한 일정)\n" +
+					"- progressPercent: (completed / totalPlanned) * 100\n\n" +
+					"**참고**: SCHEDULED 상태인 일정은 completed도 missed도 아닌 '예정' 상태입니다."
 	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청 (년도 또는 월 값이 유효하지 않음)"),
+		@ApiResponse(responseCode = "401", description = "인증되지 않음")
+	})
 	@GetMapping("/progress")
 	public ResponseEntity<DashboardProgressResponse> getProgress(
-		@RequestParam Long userId,
 		@Parameter(description = "연도 (예: 2025)", required = false)
 		@RequestParam(required = false) Integer year,
 		@Parameter(description = "월 (1~12)", required = false)
 		@RequestParam(required = false) Integer month
 	) {
+		Long userId = SecurityUtil.currentUserId();
 		DashboardProgressResponse response;
 
 		if (year != null && month != null) {

--- a/src/main/java/com/pillmate/pillmate/Repository/ScheduleRepository.java
+++ b/src/main/java/com/pillmate/pillmate/Repository/ScheduleRepository.java
@@ -39,5 +39,25 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     // 사용자, 날짜로 일정 조회
     @Query("SELECT s FROM Schedule s WHERE s.userId = :userId AND s.date = :date ORDER BY s.alarmAt")
     List<Schedule> findByUserIdAndDate(@Param("userId") Long userId, @Param("date") LocalDate date);
+    
+    // 사용자, 기간별 일정 개수 조회
+    @Query("SELECT COUNT(s) FROM Schedule s WHERE s.userId = :userId AND s.date >= :startDate AND s.date <= :endDate")
+    int countByUserIdAndDateRange(@Param("userId") Long userId, 
+                                   @Param("startDate") LocalDate startDate, 
+                                   @Param("endDate") LocalDate endDate);
+    
+    // 사용자, 기간별, 상태별 일정 개수 조회
+    @Query("SELECT COUNT(s) FROM Schedule s WHERE s.userId = :userId AND s.status = :status AND s.date >= :startDate AND s.date <= :endDate")
+    int countByUserIdAndStatusAndDateRange(@Param("userId") Long userId, 
+                                            @Param("status") com.pillmate.pillmate.Domain.ScheduleStatus status,
+                                            @Param("startDate") LocalDate startDate, 
+                                            @Param("endDate") LocalDate endDate);
+    
+    // 사용자, 기간별, 상태가 아닌 일정 개수 조회 (CANCELLED 제외용)
+    @Query("SELECT COUNT(s) FROM Schedule s WHERE s.userId = :userId AND s.status != :status AND s.date >= :startDate AND s.date <= :endDate")
+    int countByUserIdAndStatusNotAndDateRange(@Param("userId") Long userId, 
+                                               @Param("status") com.pillmate.pillmate.Domain.ScheduleStatus status,
+                                               @Param("startDate") LocalDate startDate, 
+                                               @Param("endDate") LocalDate endDate);
 
 }

--- a/src/main/java/com/pillmate/pillmate/Service/DashboardService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/DashboardService.java
@@ -1,12 +1,14 @@
 package com.pillmate.pillmate.Service;
 
 import com.pillmate.pillmate.DTO.DashboardProgressResponse;
+import com.pillmate.pillmate.Domain.ScheduleStatus;
 import com.pillmate.pillmate.Domain.User;
-import com.pillmate.pillmate.Repository.IntakeRepository;
 import com.pillmate.pillmate.Repository.ScheduleRepository;
 import com.pillmate.pillmate.Repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
 
@@ -15,7 +17,6 @@ import java.time.LocalDate;
 public class DashboardService {
 
 	private final ScheduleRepository scheduleRepository;
-	private final IntakeRepository intakeRepository;
 	private final UserRepository userRepository;
 
 	/**
@@ -30,24 +31,36 @@ public class DashboardService {
 	 * 특정 연/월 기준 대시보드 (쿼리파라미터로 year, month 들어오는 경우)
 	 */
 	public DashboardProgressResponse getProgress(Long userId, int year, int month) {
+		// 월 값 검증
+		if (month < 1 || month > 12) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "월은 1부터 12 사이의 값이어야 합니다");
+		}
 
-		// 0. 사용자 이름 가져오기
+		// 사용자 이름 가져오기
 		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"));
 
 		String userName = user.getName();
 		String periodLabel = year + "년 " + month + "월";
 
-		// 1. 이 사용자에게 등록된 전체 복용 계획 개수
-		int totalPlanned = scheduleRepository.countByUserId(userId);
+		// 해당 월의 첫 날과 마지막 날 계산
+		LocalDate firstDayOfMonth = LocalDate.of(year, month, 1);
+		LocalDate lastDayOfMonth = firstDayOfMonth.withDayOfMonth(firstDayOfMonth.lengthOfMonth());
 
-		// 2. 실제 섭취(기록)된 개수
-		int completed = intakeRepository.countByUserId(userId);
+		// 1. 해당 기간 내에 등록된 전체 복용 계획 개수 (CANCELLED 제외)
+		// SCHEDULED, TAKEN, MISSED 상태만 포함
+		int totalPlanned = scheduleRepository.countByUserIdAndStatusNotAndDateRange(
+			userId, ScheduleStatus.CANCELLED, firstDayOfMonth, lastDayOfMonth);
 
-		// 3. 누락
-		int missed = Math.max(totalPlanned - completed, 0);
+		// 2. 실제 섭취(기록)된 개수 - TAKEN 상태인 일정 개수
+		int completed = scheduleRepository.countByUserIdAndStatusAndDateRange(
+			userId, ScheduleStatus.TAKEN, firstDayOfMonth, lastDayOfMonth);
 
-		// 4. 진행률
+		// 3. 누락 (MISSED 상태인 일정 개수)
+		int missed = scheduleRepository.countByUserIdAndStatusAndDateRange(
+			userId, ScheduleStatus.MISSED, firstDayOfMonth, lastDayOfMonth);
+
+		// 4. 진행률 계산 (totalPlanned가 0이면 0%, 아니면 completed / totalPlanned * 100)
 		int adherencePercent = (totalPlanned == 0)
 			? 0
 			: (int) Math.round((completed * 100.0) / totalPlanned);

--- a/src/main/java/com/pillmate/pillmate/Service/ScheduleService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/ScheduleService.java
@@ -87,9 +87,18 @@ public class ScheduleService {
      * @param scheduleId 일정 ID
      * @return 일정 정보
      */
+    @Transactional
     public ScheduleResponse getScheduleById(Long scheduleId) {
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 일정입니다"));
+        
+        LocalDate today = LocalDate.now();
+        
+        // 날짜가 지난 SCHEDULED 일정을 자동으로 MISSED로 변경
+        if (schedule.getDate().isBefore(today) && schedule.getStatus() == ScheduleStatus.SCHEDULED) {
+            schedule.updateStatus(ScheduleStatus.MISSED);
+            scheduleRepository.save(schedule);
+        }
         
         return ScheduleResponse.from(schedule);
     }
@@ -100,8 +109,19 @@ public class ScheduleService {
      * @param date 조회할 날짜 (YYYY-MM-DD 형식)
      * @return 해당 날짜의 일정 목록
      */
+    @Transactional(readOnly = false)
     public List<ScheduleResponse> getSchedulesByDate(Long userId, LocalDate date) {
         List<Schedule> schedules = scheduleRepository.findByUserIdAndDate(userId, date);
+        LocalDate today = LocalDate.now();
+        
+        // 날짜가 지난 SCHEDULED 일정을 자동으로 MISSED로 변경
+        schedules.forEach(schedule -> {
+            if (schedule.getDate().isBefore(today) && schedule.getStatus() == ScheduleStatus.SCHEDULED) {
+                schedule.updateStatus(ScheduleStatus.MISSED);
+                scheduleRepository.save(schedule);
+            }
+        });
+        
         return schedules.stream()
                 .map(ScheduleResponse::from)
                 .collect(Collectors.toList());
@@ -114,6 +134,7 @@ public class ScheduleService {
      * @param to 종료 날짜 (YYYY-MM-DD 형식)
      * @return 해당 기간의 일정 목록
      */
+    @Transactional(readOnly = false)
     public List<ScheduleResponse> getSchedulesByDateRange(Long userId, LocalDate from, LocalDate to) {
         if (from.isAfter(to)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "시작일은 종료일보다 이전이어야 합니다");
@@ -124,6 +145,16 @@ public class ScheduleService {
         List<Schedule> userSchedules = schedules.stream()
                 .filter(s -> s.getUserId().equals(userId))
                 .collect(Collectors.toList());
+        
+        LocalDate today = LocalDate.now();
+        
+        // 날짜가 지난 SCHEDULED 일정을 자동으로 MISSED로 변경
+        userSchedules.forEach(schedule -> {
+            if (schedule.getDate().isBefore(today) && schedule.getStatus() == ScheduleStatus.SCHEDULED) {
+                schedule.updateStatus(ScheduleStatus.MISSED);
+                scheduleRepository.save(schedule);
+            }
+        });
         
         return userSchedules.stream()
                 .map(ScheduleResponse::from)
@@ -234,13 +265,29 @@ public class ScheduleService {
         // 상태 수정 및 금지 타이머 계산
         BanTimerResponse caffeineBanTimer = null;
         BanTimerResponse alcoholBanTimer = null;
+        ScheduleStatus previousStatus = schedule.getStatus();
         
-        if (request.getStatus() != null) {
+        // plan 처리 우선 (plan이 CANCELLED이면 상태를 CANCELLED로 변경)
+        boolean planCancelled = false;
+        if (request.getPlan() != null) {
+            String planValue = request.getPlan().trim().toUpperCase();
+            if ("CANCELLED".equals(planValue)) {
+                schedule.updateStatus(ScheduleStatus.CANCELLED);
+                planCancelled = true;
+            } else if ("SCHEDULED".equals(planValue)) {
+                // CANCELLED에서 SCHEDULED로 복구 (단, status가 TAKEN/MISSED가 아니면)
+                if (schedule.getStatus() == ScheduleStatus.CANCELLED) {
+                    schedule.updateStatus(ScheduleStatus.SCHEDULED);
+                }
+            }
+        }
+        
+        // 사용자가 명시적으로 status를 변경하려고 하는 경우
+        if (request.getStatus() != null && !planCancelled) {
             String statusValue = request.getStatus().trim().toUpperCase();
-            ScheduleStatus previousStatus = schedule.getStatus();
             ScheduleStatus newStatus = resolveStatus(statusValue);
             
-            // 상태 변경
+            // 상태 변경 (plan이 CANCELLED가 아닌 경우에만)
             schedule.updateStatus(newStatus);
             
             // TAKEN 상태로 변경된 경우 금지 타이머 계산
@@ -277,18 +324,17 @@ public class ScheduleService {
                     }
                 }
             }
-        }
-        
-        // plan 처리 (CANCELLED 상태로 변경)
-        if (request.getPlan() != null) {
-            String planValue = request.getPlan().trim().toUpperCase();
-            if ("CANCELLED".equals(planValue)) {
-                schedule.updateStatus(ScheduleStatus.CANCELLED);
-            } else if ("SCHEDULED".equals(planValue)) {
-                // CANCELLED에서 SCHEDULED로 복구 (단, status가 TAKEN/MISSED가 아니면)
-                if (schedule.getStatus() == ScheduleStatus.CANCELLED) {
-                    schedule.updateStatus(ScheduleStatus.SCHEDULED);
-                }
+        } else if (request.getStatus() == null && !planCancelled) {
+            // 사용자가 status를 명시적으로 변경하지 않은 경우
+            // 날짜가 지났고 SCHEDULED 상태이면 자동으로 MISSED로 변경
+            // 단, plan이 CANCELLED로 설정된 경우는 제외
+            LocalDate finalScheduleDate = request.getDate() != null ? request.getDate() : schedule.getDate();
+            LocalDate today = LocalDate.now();
+            
+            // 날짜가 오늘보다 과거이고, 현재 상태가 SCHEDULED이면 MISSED로 자동 변경
+            // CANCELLED 상태는 자동 변경하지 않음
+            if (finalScheduleDate.isBefore(today) && schedule.getStatus() == ScheduleStatus.SCHEDULED) {
+                schedule.updateStatus(ScheduleStatus.MISSED);
             }
         }
         


### PR DESCRIPTION
# 대시보드 진행률 API 개선 및 자동 MISSED 상태 변경 기능 추가

## 📋 요약

- 대시보드 진행률 API에서 SecurityUtil을 사용하여 JWT 토큰으로 사용자 ID 자동 추출
- CANCELLED 상태 일정을 진행률 계산에서 제외
- 조회/수정 시 날짜가 지난 SCHEDULED 일정을 자동으로 MISSED로 변경

## 📌 변경 사항

### 1. 대시보드 진행률 API 보안 개선
- `DashboardController`에서 `userId` 파라미터 제거
- `SecurityUtil.currentUserId()`를 사용하여 JWT 토큰에서 사용자 ID 자동 추출
- 다른 사용자 데이터 접근 방지 (보안 강화)

### 2. 대시보드 진행률 계산 로직 개선
- `DashboardService`에서 CANCELLED 상태 일정을 진행률 계산에서 제외
- `totalPlanned`: CANCELLED 제외, SCHEDULED/TAKEN/MISSED 포함
- `completed`: TAKEN 상태 일정 개수
- `missed`: MISSED 상태 일정 개수 (명시적으로 누락으로 표시한 일정)
- `ScheduleRepository`에 `countByUserIdAndStatusNotAndDateRange` 메서드 추가

### 3. 자동 MISSED 상태 변경 기능
- `ScheduleService`의 조회 메서드들에 자동 MISSED 변경 로직 추가
  - `getScheduleById()`: 단일 일정 조회 시
  - `getSchedulesByDate()`: 날짜별 일정 조회 시
  - `getSchedulesByDateRange()`: 기간별 일정 조회 시
  - `getSchedulesByMonth()`: 월별 일정 조회 시 (내부적으로 `getSchedulesByDateRange` 호출)
- `updateSchedule()`: 수정 시에도 동일한 로직 적용
- 날짜가 오늘보다 과거이고 상태가 SCHEDULED인 일정을 자동으로 MISSED로 변경

## 🔍 상세 내용

### 대시보드 진행률 API 변경
**이전:**
```
GET /api/v1/dashboard/progress?userId=1&year=2025&month=11
```

**현재:**
```
GET /api/v1/dashboard/progress?year=2025&month=11
Authorization: Bearer {JWT_TOKEN}
```

- JWT 토큰에서 사용자 ID를 자동으로 추출하므로 `userId` 파라미터 불필요
- 다른 사용자의 데이터 접근 방지

### 진행률 계산 로직
- **totalPlanned**: 해당 기간 내 등록된 일정 개수 (CANCELLED 제외)
- **completed**: TAKEN 상태인 일정 개수
- **missed**: MISSED 상태인 일정 개수
- **progressPercent**: (completed / totalPlanned) * 100

### 자동 MISSED 상태 변경
- 조회 또는 수정 시점에 날짜가 지난 SCHEDULED 일정을 자동으로 MISSED로 변경
- DB에 실제로 상태를 업데이트하므로 다음 조회 시에도 MISSED 상태 유지
- CANCELLED 상태는 자동 변경하지 않음
- 사용자가 명시적으로 status를 변경하려고 하면 사용자 입력을 우선시

### 트랜잭션 처리
- 조회 메서드들에 `@Transactional(readOnly = false)` 추가
- 상태 변경이 발생하므로 readOnly를 false로 설정

## ✅ 체크리스트

- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 보안 개선 (JWT 토큰 기반 사용자 인증)
- [x] 진행률 계산 로직 개선 (CANCELLED 제외)
- [x] 자동 MISSED 상태 변경 기능 구현

## 👀 리뷰 요청 사항

1. **대시보드 진행률 계산 로직**
   - CANCELLED 상태 일정을 제외하는 로직이 올바른지 확인
   - SCHEDULED 상태인 일정이 진행률 계산에 포함되는 것이 맞는지 확인

2. **자동 MISSED 상태 변경**
   - 조회 시점에 DB를 업데이트하는 것이 적절한지 검토
   - 배치 작업으로 처리하는 것이 더 나을지 고려 필요

3. **트랜잭션 처리**
   - 조회 메서드에 `@Transactional(readOnly = false)`를 추가한 것이 적절한지 확인
   - 성능에 영향을 주지 않는지 검토

4. **보안**
   - JWT 토큰 기반 사용자 인증이 올바르게 구현되었는지 확인
   - 다른 API와의 일관성 확인

## 📎 참고 자료

### 수정된 파일
- `src/main/java/com/pillmate/pillmate/Controller/DashboardController.java`
- `src/main/java/com/pillmate/pillmate/Service/DashboardService.java`
- `src/main/java/com/pillmate/pillmate/Repository/ScheduleRepository.java`
- `src/main/java/com/pillmate/pillmate/Service/ScheduleService.java`

### API 엔드포인트
- `GET /api/v1/dashboard/progress` - 대시보드 진행률 조회
- `GET /api/v1/main/calendar/schedules?date={date}` - 날짜별 일정 조회
- `GET /api/v1/main/calendar/schedules/{scheduleId}` - 단일 일정 조회
- `GET /api/v1/main/calendar/schedules/month?year={year}&month={month}` - 월별 일정 조회
- `PUT /api/v1/main/calendar/schedules/{scheduleId}` - 일정 수정

### 테스트 시나리오
1. **대시보드 진행률 조회**
   - JWT 토큰 없이 요청 시 401 에러 반환
   - JWT 토큰과 함께 요청 시 현재 로그인한 사용자의 진행률 반환
   - CANCELLED 상태 일정은 진행률 계산에서 제외

2. **자동 MISSED 상태 변경**
   - 과거 날짜의 SCHEDULED 일정 조회 시 자동으로 MISSED로 변경
   - 오늘 날짜 또는 미래 날짜의 SCHEDULED 일정은 변경되지 않음
   - CANCELLED 상태 일정은 변경되지 않음
