### PR TITLE
feat: 금지 타이머에 해당 날짜의 최대 회피계수 적용 및 스케줄 API 개선

### DIFF
--- a/src/main/java/com/pillmate/pillmate/Controller/ScheduleController.java
+++ b/src/main/java/com/pillmate/pillmate/Controller/ScheduleController.java
@@ -39,7 +39,7 @@ public class ScheduleController {
     
     private final ScheduleService scheduleService;
     
-    @Operation(summary = "복약 일정 등록", description = "메인 캘린더에 새로운 복약 일정을 등록합니다.")
+    @Operation(summary = "복약 일정 등록", description = "달력에서 선택한 날짜에 새로운 복약 일정을 등록합니다. 단일 날짜만 등록 가능합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "복약 일정 등록 성공"),
         @ApiResponse(responseCode = "400", description = "잘못된 요청")
@@ -57,9 +57,7 @@ public class ScheduleController {
                         .name(scheduleResponse.getName())
                         .dose(scheduleResponse.getDose())
                         .date(scheduleResponse.getDate())
-                        .alarmAt(scheduleResponse.getAlarmAt())
-                        .startDate(scheduleResponse.getStartDate())
-                        .endDate(scheduleResponse.getEndDate())
+                        .time(scheduleResponse.getTime())
                         .memo(scheduleResponse.getMemo())
                         .plan(scheduleResponse.getPlan())
                         .status(scheduleResponse.getStatus())
@@ -89,9 +87,7 @@ public class ScheduleController {
             private String name;
             private String dose;
             private java.time.LocalDate date;  // 복용 날짜
-            private java.time.LocalDateTime alarmAt;  // 복용 예정 시각
-            private java.time.LocalDate startDate;  // 복용 기간 시작일 (표시용)
-            private java.time.LocalDate endDate;  // 복용 기간 종료일 (표시용)
+            private java.time.LocalTime time;  // 복용 시간
             private String memo;
             private String plan;
             private String status;

--- a/src/main/java/com/pillmate/pillmate/DTO/AlcoholIntakeRequest.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/AlcoholIntakeRequest.java
@@ -20,9 +20,6 @@ public class AlcoholIntakeRequest {
 	@Schema(description = "잔 크기 변경 시 개별 잔 용량(mL). 카테고리 선택 시 기본 용량 대신 사용", example = "330.0")
 	private Double customVolumeMl;
 	
-	@Schema(description = "사용자가 직접 입력한 총 용량(mL). volumeMl이 제공되면 잔 단위 계산 없이 그대로 사용", example = "1000.0")
-	private Double volumeMl;
-	
 	@Schema(description = "직접 입력 사용 여부. true면 customAbv와 customVolumeMl을 사용 (우선순위 최상)", example = "false")
 	private Boolean useCustomInput;
 	

--- a/src/main/java/com/pillmate/pillmate/DTO/ScheduleRequest.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ScheduleRequest.java
@@ -1,7 +1,7 @@
 package com.pillmate.pillmate.DTO;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
@@ -31,18 +31,12 @@ public class ScheduleRequest {
     private String dose;
     
     @NotNull(message = "복용 날짜는 필수입니다")
-    @Schema(description = "복용 날짜 (YYYY-MM-DD 형식)", example = "2025-10-08", required = true)
+    @Schema(description = "복용 날짜 (YYYY-MM-DD 형식, 캘린더에서 선택한 날짜)", example = "2025-10-08", required = true)
     private LocalDate date;
     
-    @NotNull(message = "알림 시각은 필수입니다")
-    @Schema(description = "복용 예정 시각 (ISO8601 형식)", example = "2025-10-08T08:30:00", required = true)
-    private LocalDateTime alarmAt;
-    
-    @Schema(description = "복용 기간 시작일 (표시용, YYYY-MM-DD 형식)", example = "2025-10-08")
-    private LocalDate startDate;
-    
-    @Schema(description = "복용 기간 종료일 (표시용, YYYY-MM-DD 형식)", example = "2025-10-15")
-    private LocalDate endDate;
+    @NotNull(message = "복용 시간은 필수입니다")
+    @Schema(description = "복용 시간 (HH:mm 형식)", example = "08:30", required = true)
+    private LocalTime time;
     
     @Schema(description = "사용자 메모", example = "식후 30분")
     private String memo;

--- a/src/main/java/com/pillmate/pillmate/DTO/ScheduleResponse.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ScheduleResponse.java
@@ -1,7 +1,7 @@
 package com.pillmate.pillmate.DTO;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.pillmate.pillmate.Domain.Schedule;
@@ -35,14 +35,8 @@ public class ScheduleResponse {
     @Schema(description = "복용 날짜 (YYYY-MM-DD 형식)", example = "2025-10-08")
     private LocalDate date;
     
-    @Schema(description = "복용 예정 시각", example = "2025-10-08T08:30:00")
-    private LocalDateTime alarmAt;
-    
-    @Schema(description = "복용 기간 시작일 (표시용)", example = "2025-10-08")
-    private LocalDate startDate;
-    
-    @Schema(description = "복용 기간 종료일 (표시용)", example = "2025-10-15")
-    private LocalDate endDate;
+    @Schema(description = "복용 시간 (HH:mm 형식)", example = "08:30")
+    private LocalTime time;
     
     @Schema(description = "사용자 메모", example = "식후 30분")
     private String memo;
@@ -77,10 +71,8 @@ public class ScheduleResponse {
                 .drugId(schedule.getDrugId())
                 .name(schedule.getDrugName())
                 .dose(schedule.getDose())
-                .date(schedule.getDate())
-                .alarmAt(schedule.getAlarmAt())
-                .startDate(schedule.getStartDate())
-                .endDate(schedule.getEndDate())
+                .date(schedule.getDate().toLocalDate())
+                .time(schedule.getDate().toLocalTime())
                 .memo(schedule.getMemo())
                 .plan(resolvedPlan)
                 .status(resolvedStatus)
@@ -133,10 +125,8 @@ public class ScheduleResponse {
                 .drugId(schedule.getDrugId())
                 .name(schedule.getDrugName())
                 .dose(schedule.getDose())
-                .date(schedule.getDate())
-                .alarmAt(schedule.getAlarmAt())
-                .startDate(schedule.getStartDate())
-                .endDate(schedule.getEndDate())
+                .date(schedule.getDate().toLocalDate())
+                .time(schedule.getDate().toLocalTime())
                 .memo(schedule.getMemo())
                 .plan(resolvedPlan)
                 .status(resolvedStatus)

--- a/src/main/java/com/pillmate/pillmate/DTO/ScheduleUpdateRequest.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ScheduleUpdateRequest.java
@@ -1,7 +1,7 @@
 package com.pillmate.pillmate.DTO;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
@@ -26,17 +26,11 @@ public class ScheduleUpdateRequest {
     @Schema(description = "복용량 또는 용법", example = "1정")
     private String dose;
     
-    @Schema(description = "복용 날짜 (YYYY-MM-DD 형식)", example = "2025-10-08")
+    @Schema(description = "복용 날짜 (YYYY-MM-DD 형식, 캘린더에서 선택한 날짜)", example = "2025-10-08")
     private LocalDate date;
     
-    @Schema(description = "복용 예정 시각 (ISO8601 형식)", example = "2025-10-08T09:00:00")
-    private LocalDateTime alarmAt;
-    
-    @Schema(description = "복용 기간 시작일 (표시용, YYYY-MM-DD 형식)", example = "2025-10-08")
-    private LocalDate startDate;
-    
-    @Schema(description = "복용 기간 종료일 (표시용, YYYY-MM-DD 형식)", example = "2025-10-15")
-    private LocalDate endDate;
+    @Schema(description = "복용 시간 (HH:mm 형식)", example = "08:30")
+    private LocalTime time;
     
     @Schema(description = "사용자 메모", example = "시간 조정")
     private String memo;

--- a/src/main/java/com/pillmate/pillmate/DTO/ScheduleUpdateResponse.java
+++ b/src/main/java/com/pillmate/pillmate/DTO/ScheduleUpdateResponse.java
@@ -1,7 +1,7 @@
 package com.pillmate.pillmate.DTO;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -31,14 +31,8 @@ public class ScheduleUpdateResponse {
     @Schema(description = "복용 날짜 (YYYY-MM-DD 형식)", example = "2025-10-08")
     private LocalDate date;
     
-    @Schema(description = "복용 예정 시각", example = "2025-10-08T09:00:00")
-    private LocalDateTime alarmAt;
-    
-    @Schema(description = "복용 기간 시작일 (표시용)", example = "2025-10-08")
-    private LocalDate startDate;
-    
-    @Schema(description = "복용 기간 종료일 (표시용)", example = "2025-10-15")
-    private LocalDate endDate;
+    @Schema(description = "복용 시간 (HH:mm 형식)", example = "08:30")
+    private LocalTime time;
     
     @Schema(description = "사용자 메모", example = "시간 조정")
     private String memo;

--- a/src/main/java/com/pillmate/pillmate/Domain/Schedule.java
+++ b/src/main/java/com/pillmate/pillmate/Domain/Schedule.java
@@ -47,7 +47,7 @@ public class Schedule {
     private String dose;  // 복용량 또는 용법
     
     @Column(nullable = false)
-    private LocalDate date;  // 복용 날짜 (단일 날짜)
+    private LocalDateTime date;  // 복용 날짜 및 시각
     
     @Column(nullable = false)
     private LocalDateTime alarmAt;  // 복용 예정 시각
@@ -100,7 +100,7 @@ public class Schedule {
         this.alarmEnabled = alarmEnabled;
     }
     
-    public void updateDate(LocalDate date) {
+    public void updateDate(LocalDateTime date) {
         this.date = date;
     }
     

--- a/src/main/java/com/pillmate/pillmate/Repository/IntakeRepository.java
+++ b/src/main/java/com/pillmate/pillmate/Repository/IntakeRepository.java
@@ -24,4 +24,7 @@ public interface IntakeRepository extends JpaRepository<Intake, Long> {
 	
 	// 사용자별 특정 타입의 최신 섭취 기록 조회
 	Optional<Intake> findTopByUserIdAndIntakeTypeOrderByCreatedAtDesc(Long userId, IntakeType intakeType);
+	
+	// 사용자별 특정 타입의 모든 섭취 기록 조회 (최신순)
+	List<Intake> findByUserIdAndIntakeTypeOrderByCreatedAtDesc(Long userId, IntakeType intakeType);
 }

--- a/src/main/java/com/pillmate/pillmate/Repository/ScheduleRepository.java
+++ b/src/main/java/com/pillmate/pillmate/Repository/ScheduleRepository.java
@@ -25,8 +25,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Query("SELECT s FROM Schedule s WHERE s.date = :date ORDER BY s.alarmAt")
     List<Schedule> findByDate(@Param("date") LocalDate date);
     
-    // 특정 기간의 일정 조회
-    @Query("SELECT s FROM Schedule s WHERE s.date >= :startDate AND s.date <= :endDate ORDER BY s.date, s.alarmAt")
+    // 특정 기간의 일정 조회 (LocalDate를 받아서 해당 날짜 범위의 모든 일정 조회)
+    @Query("SELECT s FROM Schedule s WHERE DATE(s.date) >= :startDate AND DATE(s.date) <= :endDate ORDER BY s.date, s.alarmAt")
     List<Schedule> findByDateRange(@Param("startDate") LocalDate startDate, 
                                     @Param("endDate") LocalDate endDate);
     
@@ -36,8 +36,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     // 사용자, 약물, 상태로 일정 조회
     List<Schedule> findByUserIdAndDrugIdAndStatus(Long userId, Long drugId, com.pillmate.pillmate.Domain.ScheduleStatus status);
     
-    // 사용자, 날짜로 일정 조회
-    @Query("SELECT s FROM Schedule s WHERE s.userId = :userId AND s.date = :date ORDER BY s.alarmAt")
+    // 사용자, 날짜로 일정 조회 (LocalDate를 받아서 해당 날짜의 모든 일정 조회)
+    @Query("SELECT s FROM Schedule s WHERE s.userId = :userId AND DATE(s.date) = :date ORDER BY s.alarmAt")
     List<Schedule> findByUserIdAndDate(@Param("userId") Long userId, @Param("date") LocalDate date);
     
     // 사용자, 기간별 일정 개수 조회

--- a/src/main/java/com/pillmate/pillmate/Service/IntakeService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/IntakeService.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -146,7 +145,7 @@ public class IntakeService {
 	// 2️⃣ 알코올 전용 섭취 등록
 	// ===========================
 	public IntakeResponse createAlcoholIntake(Long userId, AlcoholIntakeRequest req) {
-		// 직접 입력 우선순위 확인
+		// 직접 입력 모드 확인
 		Boolean useCustomInput = req.getUseCustomInput() != null && req.getUseCustomInput();
 		double finalAmount;
 		Double finalAbv = null;
@@ -157,30 +156,28 @@ public class IntakeService {
 			int cupCount = req.getCupCount() != null ? req.getCupCount() : 1;
 			finalAmount = volumePerCup * cupCount;
 			finalAbv = req.getCustomAbv();
-		} else if (req.getVolumeMl() != null && req.getVolumeMl() > 0.0) {
-			// volumeMl이 직접 제공된 경우 그대로 사용
-			finalAmount = req.getVolumeMl();
-			// volumeMl만 제공되고 customAbv가 있으면 그것 사용, 없으면 카테고리 기본값
-			if (req.getCustomAbv() != null && req.getCustomAbv() > 0.0) {
-				finalAbv = req.getCustomAbv();
-			} else {
-				finalAbv = getAbvByType(req.getAlcoholType());
-			}
 		} else {
 			// 카테고리 선택 모드: 기본 용량 또는 커스텀 용량과 잔수로 계산
+			// 잔당 용량 결정: customVolumeMl이 있으면 사용, 없으면 alcoholType 기본값
 			double volumePerCup;
 			if (req.getCustomVolumeMl() != null && req.getCustomVolumeMl() > 0.0) {
 				// 사용자가 잔 크기를 변경한 경우
 				volumePerCup = req.getCustomVolumeMl();
 			} else {
-				// 기본 용량 사용
+				// 기본 용량 사용 (alcoholType 필수)
 				volumePerCup = getDefaultVolumeByType(req.getAlcoholType());
 			}
 			
 			// 잔수 계산 (기본값 1잔)
 			int cupCount = req.getCupCount() != null ? req.getCupCount() : 1;
 			finalAmount = volumePerCup * cupCount;
-			finalAbv = getAbvByType(req.getAlcoholType());
+			
+			// 도수 결정: customAbv가 있으면 사용, 없으면 alcoholType 기본값
+			if (req.getCustomAbv() != null && req.getCustomAbv() > 0.0) {
+				finalAbv = req.getCustomAbv();
+			} else {
+				finalAbv = getAbvByType(req.getAlcoholType());
+			}
 		}
 
 		LocalDateTime intakeAt = resolveIntakeAt(
@@ -277,8 +274,9 @@ public class IntakeService {
 			intakeId, intakeAt, now, String.format("%.2f", hoursPassed), String.format("%.2f", initialMg), 
 			String.format("%.2f", halfLifeHours), String.format("%.2f", currentMg));
 		
-		// 사용자가 복용 중인 약물 중 가장 높은 보정계수 찾기
-		double maxAdjustmentFactor = findMaxAdjustmentFactor(userId);
+		// 사용자가 복용 중인 약물 중 가장 높은 보정계수 찾기 (섭취 날짜 기준)
+		LocalDate intakeDate = intakeAt.toLocalDate();
+		double maxAdjustmentFactor = findMaxAdjustmentFactor(userId, intakeDate);
 		
 		// 30mg 미만이 되기까지 필요한 시간 계산
 		// 30 = initialMg × (0.5)^(t / halfLifeHours)
@@ -363,7 +361,21 @@ public class IntakeService {
 		// 현재 시간과 섭취 시각 비교
 		LocalDateTime now = LocalDateTime.now();
 		LocalDateTime intakeAt = intake.getCreatedAt();
-		double hoursPassed = ChronoUnit.SECONDS.between(intakeAt, now) / 3600.0;
+		
+		// 경과 시간 계산 (초 단위)
+		long secondsPassed = ChronoUnit.SECONDS.between(intakeAt, now);
+		
+		// 섭취 시각이 미래인 경우 0으로 처리 (아직 섭취하지 않은 경우)
+		if (secondsPassed < 0) {
+			log.warn("알코올 섭취 시각이 미래입니다. intakeAt: {}, now: {}, intakeId: {}", intakeAt, now, intakeId);
+			secondsPassed = 0;
+		}
+		
+		double hoursPassed = secondsPassed / 3600.0;
+		
+		// 디버깅 로그
+		log.info("알코올 잔존량 계산 - intakeId: {}, intakeAt: {}, now: {}, secondsPassed: {}s, hoursPassed: {}h", 
+			intakeId, intakeAt, now, secondsPassed, String.format("%.6f", hoursPassed));
 		
 		// 술 종류별 기본 용량 및 도수 가져오기
 		String alcoholType = intake.getBeverageName();
@@ -384,6 +396,13 @@ public class IntakeService {
 		// BAC_now = max(0, BAC_peak − rate × 경과시간_h)
 		double bacNow = Math.max(0.0, bacPeak - (rate * hoursPassed));
 		
+		// 디버깅 로그
+		log.info("알코올 BAC 계산 - intakeId: {}, volumeMl: {}, abv: {}%, standardDrinks: {}, bacPeak: {}%, hoursPassed: {}h, rate: {}%/h, bacNow: {}%, threshold: {}%", 
+			intakeId, String.format("%.2f", volumeMl), String.format("%.2f", abv), 
+			String.format("%.2f", standardDrinks), String.format("%.6f", bacPeak), 
+			String.format("%.2f", hoursPassed), String.format("%.6f", rate),
+			String.format("%.6f", bacNow), String.format("%.6f", ALCOHOL_THRESHOLD_BAC));
+		
 		// 0.02% 미만이 되기까지 필요한 시간 계산
 		// t_to_threshold = max(0, (BAC_now − 0.02) ÷ rate)
 		double timeToThresholdHours = 0.0;
@@ -391,8 +410,9 @@ public class IntakeService {
 			timeToThresholdHours = (bacNow - ALCOHOL_THRESHOLD_BAC) / rate;
 		}
 		
-		// 사용자가 복용 중인 약물 중 가장 높은 보정계수 찾기
-		double maxAdjustmentFactor = findMaxAdjustmentFactor(userId);
+		// 사용자가 복용 중인 약물 중 가장 높은 보정계수 찾기 (섭취 날짜 기준)
+		LocalDate intakeDate = intakeAt.toLocalDate();
+		double maxAdjustmentFactor = findMaxAdjustmentFactor(userId, intakeDate);
 		
 		// 약물군 보정계수 적용
 		double finalTimeHours = timeToThresholdHours * maxAdjustmentFactor;
@@ -408,6 +428,11 @@ public class IntakeService {
 		
 		// 이미 복약 가능한지 여부
 		boolean isSafe = bacNow <= ALCOHOL_THRESHOLD_BAC;
+		
+		// 디버깅 로그
+		log.info("알코올 isSafe 계산 - intakeId: {}, bacNow: {}%, threshold: {}%, isSafe: {}, remainingSec: {}, currentAmount(응답용): {}", 
+			intakeId, String.format("%.6f", bacNow), String.format("%.6f", ALCOHOL_THRESHOLD_BAC), 
+			isSafe, remainingSec, String.format("%.2f", bacNow * 100));
 		
 		// 가정값들
 		Map<String, Object> assumptions = new HashMap<>();
@@ -432,26 +457,26 @@ public class IntakeService {
 	}
 
 	/**
-	 * 사용자의 복약 일정에서 현재 날짜의 약물에 대한 보정계수 찾기
+	 * 사용자의 복약 일정에서 특정 날짜의 약물에 대한 보정계수 찾기
 	 * 
 	 * 로직:
-	 * 1. 현재 날짜의 복약 일정 조회 (SCHEDULED 상태만)
+	 * 1. 특정 날짜의 복약 일정 조회 (SCHEDULED 상태만)
 	 * 2. 일정이 없으면 보정계수 적용 안 함 (기본값 1.0 반환)
 	 * 3. 여러 개의 약물이 있으면 보정계수가 가장 높은 것을 반환
 	 * 
 	 * @param userId 사용자 ID
+	 * @param targetDate 조회할 날짜 (섭취 날짜 또는 현재 날짜)
 	 * @return 약물군 보정계수 (없으면 1.0, 여러 개면 최대값)
 	 */
-	private double findMaxAdjustmentFactor(Long userId) {
-		// 현재 날짜 기준으로 복약 일정 조회 (SCHEDULED 상태만)
-		LocalDate today = LocalDate.now();
-		List<Schedule> allSchedules = scheduleRepository.findByUserIdAndDate(userId, today);
+	private double findMaxAdjustmentFactor(Long userId, LocalDate targetDate) {
+		// 특정 날짜 기준으로 복약 일정 조회 (SCHEDULED 상태만)
+		List<Schedule> allSchedules = scheduleRepository.findByUserIdAndDate(userId, targetDate);
 		List<Schedule> activeSchedules = allSchedules.stream()
 			.filter(s -> s.getStatus() == ScheduleStatus.SCHEDULED)
 			.collect(Collectors.toList());
 		
-		log.debug("보정계수 조회 - userId: {}, today: {}, 전체 일정 수: {}, SCHEDULED 일정 수: {}", 
-			userId, today, allSchedules.size(), activeSchedules.size());
+		log.debug("보정계수 조회 - userId: {}, targetDate: {}, 전체 일정 수: {}, SCHEDULED 일정 수: {}", 
+			userId, targetDate, allSchedules.size(), activeSchedules.size());
 		
 		// 일정이 없으면 보정계수 적용 안 함 (기본값 1.0 반환)
 		if (activeSchedules.isEmpty()) {
@@ -543,50 +568,102 @@ public class IntakeService {
 		ActiveTimerListResponse.ActiveTimerItem caffeineTimer = null;
 		ActiveTimerListResponse.ActiveTimerItem alcoholTimer = null;
 		
-		// 카페인 최신 기록 조회
-		Optional<Intake> latestCaffeine = intakeRepository.findTopByUserIdAndIntakeTypeOrderByCreatedAtDesc(userId, IntakeType.CAFFEINE);
-		if (latestCaffeine.isPresent()) {
-			Intake intake = latestCaffeine.get();
-			ResidualTimerResponse timer = calculateCaffeineResidualTimer(userId, intake.getIntakeId());
-			
-			// 활성 타이머만 포함 (아직 복약 불가능한 경우)
-			if (timer != null && !timer.getIsSafe()) {
-				caffeineTimer = ActiveTimerListResponse.ActiveTimerItem.builder()
-					.intakeId(intake.getIntakeId())
-					.intakeType("CAFFEINE")
-					.name(intake.getBeverageName())
-					.amount(intake.getAmount())
-					.abv(null)  // 카페인은 도수 없음
-					.intakeAt(intake.getCreatedAt())
-					.currentAmount(timer.getCurrentAmount())
-					.remainingSec(timer.getRemainingSec())
-					.expectedSafeTime(timer.getExpectedSafeTime())
-					.isSafe(timer.getIsSafe())
-					.build();
+		// 카페인 기록 조회: 최신 기록부터 순서대로 확인하여 isSafe=false인 첫 번째 기록 찾기
+		List<Intake> caffeineIntakes = intakeRepository.findByUserIdAndIntakeTypeOrderByCreatedAtDesc(userId, IntakeType.CAFFEINE);
+		if (!caffeineIntakes.isEmpty()) {
+			for (Intake intake : caffeineIntakes) {
+				try {
+					log.debug("카페인 기록 확인: intakeId={}, beverageName={}, amount={}", 
+						intake.getIntakeId(), intake.getBeverageName(), intake.getAmount());
+					
+					ResidualTimerResponse timer = calculateCaffeineResidualTimer(userId, intake.getIntakeId());
+					log.debug("카페인 타이머 계산 결과: intakeId={}, timer={}, isSafe={}, currentAmount={}, remainingSec={}", 
+						intake.getIntakeId(), timer != null ? "not null" : "null", 
+						timer != null ? timer.getIsSafe() : "N/A",
+						timer != null ? timer.getCurrentAmount() : "N/A",
+						timer != null ? timer.getRemainingSec() : "N/A");
+					
+					// 활성 타이머만 포함 (아직 복약 불가능한 경우, isSafe가 false인 경우)
+					if (timer != null && !timer.getIsSafe()) {
+						caffeineTimer = ActiveTimerListResponse.ActiveTimerItem.builder()
+							.intakeId(intake.getIntakeId())
+							.intakeType("CAFFEINE")
+							.name(intake.getBeverageName())
+							.amount(intake.getAmount())
+							.abv(null)  // 카페인은 도수 없음
+							.intakeAt(intake.getCreatedAt())
+							.currentAmount(timer.getCurrentAmount())
+							.remainingSec(timer.getRemainingSec())
+							.expectedSafeTime(timer.getExpectedSafeTime())
+							.isSafe(timer.getIsSafe())
+							.build();
+						log.info("카페인 활성 타이머 생성 완료: intakeId={}, isSafe={}, remainingSec={}", 
+							intake.getIntakeId(), timer.getIsSafe(), timer.getRemainingSec());
+						break; // isSafe=false인 첫 번째 기록을 찾았으므로 종료
+					} else if (timer != null) {
+						log.info("카페인 타이머는 안전 상태입니다 (제외됨): intakeId={}, isSafe={}", 
+							intake.getIntakeId(), timer.getIsSafe());
+					} else {
+						log.warn("카페인 타이머가 null입니다: intakeId={}", intake.getIntakeId());
+					}
+				} catch (Exception e) {
+					log.error("카페인 타이머 계산 중 오류 발생: userId={}, intakeId={}", 
+						userId, intake.getIntakeId(), e);
+					// 오류가 발생해도 다음 기록 계속 확인
+				}
 			}
+		} else {
+			log.debug("카페인 기록이 없습니다: userId={}", userId);
 		}
 		
-		// 알코올 최신 기록 조회
-		Optional<Intake> latestAlcohol = intakeRepository.findTopByUserIdAndIntakeTypeOrderByCreatedAtDesc(userId, IntakeType.ALCOHOL);
-		if (latestAlcohol.isPresent()) {
-			Intake intake = latestAlcohol.get();
-			ResidualTimerResponse timer = calculateAlcoholResidualTimer(userId, intake.getIntakeId());
-			
-			// 활성 타이머만 포함 (아직 복약 불가능한 경우)
-			if (timer != null && !timer.getIsSafe()) {
-				alcoholTimer = ActiveTimerListResponse.ActiveTimerItem.builder()
-					.intakeId(intake.getIntakeId())
-					.intakeType("ALCOHOL")
-					.name(intake.getBeverageName())
-					.amount(intake.getAmount())
-					.abv(intake.getAbv() != null ? intake.getAbv() : getAbvByType(intake.getBeverageName()))
-					.intakeAt(intake.getCreatedAt())
-					.currentAmount(timer.getCurrentAmount())
-					.remainingSec(timer.getRemainingSec())
-					.expectedSafeTime(timer.getExpectedSafeTime())
-					.isSafe(timer.getIsSafe())
-					.build();
+		// 알코올 기록 조회: 최신 기록부터 순서대로 확인하여 isSafe=false인 첫 번째 기록 찾기
+		List<Intake> alcoholIntakes = intakeRepository.findByUserIdAndIntakeTypeOrderByCreatedAtDesc(userId, IntakeType.ALCOHOL);
+		if (!alcoholIntakes.isEmpty()) {
+			for (Intake intake : alcoholIntakes) {
+				try {
+					log.info("알코올 기록 확인: intakeId={}, beverageName={}, amount={}, abv={}, createdAt={}", 
+						intake.getIntakeId(), intake.getBeverageName(), intake.getAmount(), 
+						intake.getAbv(), intake.getCreatedAt());
+					
+					ResidualTimerResponse timer = calculateAlcoholResidualTimer(userId, intake.getIntakeId());
+					log.info("알코올 타이머 계산 결과: intakeId={}, timer={}, isSafe={}, currentAmount={}, threshold={}, remainingSec={}", 
+						intake.getIntakeId(), timer != null ? "not null" : "null", 
+						timer != null ? timer.getIsSafe() : "N/A",
+						timer != null ? timer.getCurrentAmount() : "N/A",
+						timer != null ? timer.getThreshold() : "N/A",
+						timer != null ? timer.getRemainingSec() : "N/A");
+					
+					// 활성 타이머만 포함 (아직 복약 불가능한 경우, isSafe가 false인 경우)
+					if (timer != null && !timer.getIsSafe()) {
+						alcoholTimer = ActiveTimerListResponse.ActiveTimerItem.builder()
+							.intakeId(intake.getIntakeId())
+							.intakeType("ALCOHOL")
+							.name(intake.getBeverageName())
+							.amount(intake.getAmount())
+							.abv(intake.getAbv() != null ? intake.getAbv() : getAbvByType(intake.getBeverageName()))
+							.intakeAt(intake.getCreatedAt())
+							.currentAmount(timer.getCurrentAmount())
+							.remainingSec(timer.getRemainingSec())
+							.expectedSafeTime(timer.getExpectedSafeTime())
+							.isSafe(timer.getIsSafe())
+							.build();
+						log.info("알코올 활성 타이머 생성 완료: intakeId={}, isSafe={}, remainingSec={}", 
+							intake.getIntakeId(), timer.getIsSafe(), timer.getRemainingSec());
+						break; // isSafe=false인 첫 번째 기록을 찾았으므로 종료
+					} else if (timer != null) {
+						log.info("알코올 타이머는 안전 상태입니다 (제외됨): intakeId={}, isSafe={}", 
+							intake.getIntakeId(), timer.getIsSafe());
+					} else {
+						log.warn("알코올 타이머가 null입니다: intakeId={}", intake.getIntakeId());
+					}
+				} catch (Exception e) {
+					log.error("알코올 타이머 계산 중 오류 발생: userId={}, intakeId={}", 
+						userId, intake.getIntakeId(), e);
+					// 오류가 발생해도 다음 기록 계속 확인
+				}
 			}
+		} else {
+			log.debug("알코올 기록이 없습니다: userId={}", userId);
 		}
 		
 		return ActiveTimerListResponse.builder()

--- a/src/main/java/com/pillmate/pillmate/Service/MedicationIntakeService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/MedicationIntakeService.java
@@ -13,9 +13,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -57,9 +59,10 @@ public class MedicationIntakeService {
         
         // 금지 타이머 계산 (기본 시간 × 보정 계수)
         // TAKEN 상태로 변경되면 카페인 6시간, 알코올 7시간 × 보정 계수만큼 금지
+        // 해당 날짜의 모든 SCHEDULED 일정 중 가장 높은 회피계수 사용
         List<BanTimerResponse> banTimers = calculateBanTimers(
-                request.getTakenAt(), 
-                request.getDrugId()
+                schedule.getUserId(),
+                request.getTakenAt()
         );
         
         return MedicationIntakeResponse.builder()
@@ -74,35 +77,37 @@ public class MedicationIntakeService {
      * 금지 타이머 계산
      * 기본 시간 × 보정 계수 방식으로 계산
      * TAKEN 상태로 변경되면 활성화되는 금지 타이머
+     * 해당 날짜의 모든 SCHEDULED 일정 중 가장 높은 회피계수 사용
      * 
+     * @param userId 사용자 ID
      * @param takenAt 복용 시각
-     * @param drugId 약품 ID (약물군 보정 계수 조회용)
      * @return 금지 타이머 리스트 (카페인, 알코올)
      */
     private List<BanTimerResponse> calculateBanTimers(
-            LocalDateTime takenAt, 
-            Long drugId) {
-        return calculateBanTimersInternal(takenAt, drugId);
+            Long userId,
+            LocalDateTime takenAt) {
+        return calculateBanTimersInternal(userId, takenAt);
     }
     
     /**
      * 금지 타이머 계산 (public 메서드)
      * 기본 시간 × 보정 계수 방식으로 계산
      * TAKEN 상태로 변경되면 활성화되는 금지 타이머
+     * 해당 날짜의 모든 SCHEDULED 일정 중 가장 높은 회피계수 사용
      * 
+     * @param userId 사용자 ID
      * @param takenAt 복용 시각
-     * @param drugId 약품 ID (약물군 보정 계수 조회용)
      * @return 금지 타이머 리스트 (카페인, 알코올)
      */
     public List<BanTimerResponse> calculateBanTimersInternal(
-            LocalDateTime takenAt, 
-            Long drugId) {
+            Long userId,
+            LocalDateTime takenAt) {
         
         List<BanTimerResponse> banTimers = new ArrayList<>();
         
-        // 약물군 보정 계수 조회 (카페인과 알코올 동일한 계수 사용)
-        String drugIdString = String.valueOf(drugId);
-        double adjustmentFactor = drugClassificationService.getCaffeineAdjustmentFactor(drugIdString);
+        // 해당 날짜의 모든 SCHEDULED 일정 중 가장 높은 회피계수 조회
+        LocalDate targetDate = takenAt.toLocalDate();
+        double adjustmentFactor = findMaxAdjustmentFactor(userId, targetDate);
         
         // 현재 시간 기준으로 남은 금지 시간 계산
         LocalDateTime now = LocalDateTime.now();
@@ -147,14 +152,15 @@ public class MedicationIntakeService {
     /**
      * 카페인 금지 타이머 계산 (기본 시간 × 보정 계수)
      * TAKEN 상태로 변경되면 활성화되는 금지 타이머
+     * 해당 날짜의 모든 SCHEDULED 일정 중 가장 높은 회피계수 사용
      * 
+     * @param userId 사용자 ID
      * @param takenAt 복용 시각
-     * @param drugId 약품 ID (약물군 보정 계수 조회용)
      * @return 카페인 금지 타이머
      */
-    public BanTimerResponse calculateCaffeineBanTimer(LocalDateTime takenAt, Long drugId) {
-        String drugIdString = String.valueOf(drugId);
-        double adjustmentFactor = drugClassificationService.getCaffeineAdjustmentFactor(drugIdString);
+    public BanTimerResponse calculateCaffeineBanTimer(Long userId, LocalDateTime takenAt) {
+        LocalDate targetDate = takenAt.toLocalDate();
+        double adjustmentFactor = findMaxAdjustmentFactor(userId, targetDate);
         
         // 기본 시간(6시간) × 보정 계수
         long banSeconds = (long) (CAFFEINE_BASE_BAN_HOURS * 3600 * adjustmentFactor);
@@ -171,14 +177,15 @@ public class MedicationIntakeService {
     /**
      * 알코올 금지 타이머 계산 (기본 시간 × 보정 계수)
      * TAKEN 상태로 변경되면 활성화되는 금지 타이머
+     * 해당 날짜의 모든 SCHEDULED 일정 중 가장 높은 회피계수 사용
      * 
+     * @param userId 사용자 ID
      * @param takenAt 복용 시각
-     * @param drugId 약품 ID (약물군 보정 계수 조회용)
      * @return 알코올 금지 타이머
      */
-    public BanTimerResponse calculateAlcoholBanTimer(LocalDateTime takenAt, Long drugId) {
-        String drugIdString = String.valueOf(drugId);
-        double adjustmentFactor = drugClassificationService.getCaffeineAdjustmentFactor(drugIdString);
+    public BanTimerResponse calculateAlcoholBanTimer(Long userId, LocalDateTime takenAt) {
+        LocalDate targetDate = takenAt.toLocalDate();
+        double adjustmentFactor = findMaxAdjustmentFactor(userId, targetDate);
         
         // 기본 시간(7시간) × 보정 계수
         long banSeconds = (long) (ALCOHOL_BASE_BAN_HOURS * 3600 * adjustmentFactor);
@@ -229,11 +236,10 @@ public class MedicationIntakeService {
         }
         
         LocalDateTime takenAt = latestIntake.getTakenAt();
-        Long drugId = schedule.getDrugId();
         
-        // 약물군 보정 계수 조회
-        String drugIdString = String.valueOf(drugId);
-        double adjustmentFactor = drugClassificationService.getCaffeineAdjustmentFactor(drugIdString);
+        // 해당 날짜의 모든 SCHEDULED 일정 중 가장 높은 회피계수 조회
+        LocalDate targetDate = takenAt.toLocalDate();
+        double adjustmentFactor = findMaxAdjustmentFactor(schedule.getUserId(), targetDate);
         
         // 기본 금지 시간(6시간) × 보정 계수
         long totalBanSeconds = (long) (CAFFEINE_BASE_BAN_HOURS * 3600 * adjustmentFactor);
@@ -293,11 +299,10 @@ public class MedicationIntakeService {
         }
         
         LocalDateTime takenAt = latestIntake.getTakenAt();
-        Long drugId = schedule.getDrugId();
         
-        // 약물군 보정 계수 조회
-        String drugIdString = String.valueOf(drugId);
-        double adjustmentFactor = drugClassificationService.getCaffeineAdjustmentFactor(drugIdString);
+        // 해당 날짜의 모든 SCHEDULED 일정 중 가장 높은 회피계수 조회
+        LocalDate targetDate = takenAt.toLocalDate();
+        double adjustmentFactor = findMaxAdjustmentFactor(schedule.getUserId(), targetDate);
         
         // 기본 금지 시간(7시간) × 보정 계수
         long totalBanSeconds = (long) (ALCOHOL_BASE_BAN_HOURS * 3600 * adjustmentFactor);
@@ -318,5 +323,50 @@ public class MedicationIntakeService {
                 .remainingSec(remainingSeconds)
                 .expectedSafeTime(expectedSafeTime)
                 .build();
+    }
+    
+    /**
+     * 사용자의 복약 일정에서 특정 날짜의 약물에 대한 보정계수 찾기
+     * 
+     * 로직:
+     * 1. 특정 날짜의 복약 일정 조회 (SCHEDULED 상태만)
+     * 2. 일정이 없으면 보정계수 적용 안 함 (기본값 1.0 반환)
+     * 3. 여러 개의 약물이 있으면 보정계수가 가장 높은 것을 반환
+     * 
+     * @param userId 사용자 ID
+     * @param targetDate 조회할 날짜 (복용 날짜)
+     * @return 약물군 보정계수 (없으면 1.0, 여러 개면 최대값)
+     */
+    private double findMaxAdjustmentFactor(Long userId, LocalDate targetDate) {
+        // 특정 날짜 기준으로 복약 일정 조회 (SCHEDULED 상태만)
+        List<Schedule> allSchedules = scheduleRepository.findByUserIdAndDate(userId, targetDate);
+        List<Schedule> activeSchedules = allSchedules.stream()
+            .filter(s -> s.getStatus() == ScheduleStatus.SCHEDULED)
+            .collect(Collectors.toList());
+        
+        log.debug("보정계수 조회 - userId: {}, targetDate: {}, 전체 일정 수: {}, SCHEDULED 일정 수: {}", 
+            userId, targetDate, allSchedules.size(), activeSchedules.size());
+        
+        // 일정이 없으면 보정계수 적용 안 함 (기본값 1.0 반환)
+        if (activeSchedules.isEmpty()) {
+            log.debug("SCHEDULED 상태 일정이 없어서 보정계수 1.0 반환");
+            return 1.0;
+        }
+        
+        // 각 약물의 보정계수 계산하고 최대값 찾기
+        // 여러 개의 약물이 있으면 보정계수가 가장 높은 것을 적용
+        double maxFactor = 1.0;
+        for (Schedule schedule : activeSchedules) {
+            String drugIdString = String.valueOf(schedule.getDrugId());
+            double factor = drugClassificationService.getCaffeineAdjustmentFactor(drugIdString);
+            log.debug("약물 보정계수 조회 - scheduleId: {}, drugId: {}, drugName: {}, factor: {}", 
+                schedule.getScheduleId(), schedule.getDrugId(), schedule.getDrugName(), factor);
+            if (factor > maxFactor) {
+                maxFactor = factor;
+            }
+        }
+        
+        log.debug("최종 보정계수: {}", maxFactor);
+        return maxFactor;
     }
 }

--- a/src/main/java/com/pillmate/pillmate/Service/ScheduleMigrationService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/ScheduleMigrationService.java
@@ -1,0 +1,116 @@
+package com.pillmate.pillmate.Service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pillmate.pillmate.Domain.Schedule;
+import com.pillmate.pillmate.Domain.ScheduleStatus;
+import com.pillmate.pillmate.Repository.ScheduleRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 단일 일정 방식으로 마이그레이션하기 위한 서비스
+ * 기존 기간 기반 일정(startDate ~ endDate)을 단일 날짜 기반 일정으로 변환
+ * 
+ * 주의: 이 서비스는 일회성 마이그레이션용입니다.
+ * 마이그레이션 완료 후에는 사용하지 않아도 됩니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ScheduleMigrationService {
+    
+    private final ScheduleRepository scheduleRepository;
+    
+    /**
+     * 기간 기반 일정을 단일 일정으로 분할
+     * 
+     * 주의: 이 메서드는 기존 스키마(startDate, endDate 포함)에서만 작동합니다.
+     * 마이그레이션 후에는 사용하지 않아도 됩니다.
+     */
+    @Transactional
+    public void migrateSchedulesToSingleDate() {
+        log.info("Starting schedule migration to single date format...");
+        
+        // 기존 스키마에서 startDate, endDate가 있는 일정들을 찾아서 분할
+        // 참고: 현재 Schedule 엔티티에는 startDate, endDate가 없으므로
+        // 이 서비스는 마이그레이션 전에 실행해야 합니다.
+        
+        // 실제 구현은 기존 데이터베이스에 직접 쿼리하거나
+        // 별도의 마이그레이션 스크립트를 사용하는 것을 권장합니다.
+        
+        log.info("Schedule migration completed.");
+    }
+    
+    /**
+     * 특정 기간의 일정을 단일 일정으로 분할 (예시)
+     * 
+     * @param scheduleId 기존 일정 ID
+     * @param startDate 시작 날짜
+     * @param endDate 종료 날짜
+     * @param originalSchedule 원본 일정 정보
+     */
+    @Transactional
+    public void splitScheduleByDateRange(
+            Long scheduleId,
+            LocalDate startDate,
+            LocalDate endDate,
+            Schedule originalSchedule) {
+        
+        log.info("Splitting schedule {} from {} to {}", scheduleId, startDate, endDate);
+        
+        LocalDate currentDate = startDate;
+        int dayOffset = 0;
+        
+        while (!currentDate.isAfter(endDate)) {
+            // 각 날짜마다 새로운 일정 생성
+            LocalDateTime newAlarmAt = currentDate.atTime(
+                originalSchedule.getAlarmAt().toLocalTime()
+            );
+            
+            // 중복 체크
+            boolean exists = scheduleRepository.findByDrugIdAndDateAndAlarmAt(
+                originalSchedule.getDrugId(),
+                currentDate,
+                newAlarmAt
+            ).stream()
+            .anyMatch(s -> s.getUserId().equals(originalSchedule.getUserId()));
+            
+            if (!exists) {
+                // date를 LocalDateTime으로 변환 (alarmAt과 동일한 날짜/시간 사용)
+                LocalDateTime scheduleDateTime = newAlarmAt;
+                
+                Schedule newSchedule = Schedule.builder()
+                    .userId(originalSchedule.getUserId())
+                    .drugId(originalSchedule.getDrugId())
+                    .drugName(originalSchedule.getDrugName())
+                    .dose(originalSchedule.getDose())
+                    .date(scheduleDateTime)
+                    .alarmAt(newAlarmAt)
+                    .memo(originalSchedule.getMemo())
+                    .alarmEnabled(originalSchedule.getAlarmEnabled())
+                    .repeatRule(originalSchedule.getRepeatRule())
+                    .status(originalSchedule.getStatus())
+                    .build();
+                
+                scheduleRepository.save(newSchedule);
+                log.info("Created new schedule for date: {}", currentDate);
+            }
+            
+            currentDate = currentDate.plusDays(1);
+            dayOffset++;
+        }
+        
+        // 원본 일정 삭제 (분할 완료 후)
+        scheduleRepository.deleteById(scheduleId);
+        log.info("Deleted original schedule: {}", scheduleId);
+    }
+}
+
+

--- a/src/main/java/com/pillmate/pillmate/Service/ScheduleService.java
+++ b/src/main/java/com/pillmate/pillmate/Service/ScheduleService.java
@@ -22,6 +22,8 @@ import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,39 +39,29 @@ public class ScheduleService {
     
     @Transactional
     public ScheduleResponse createSchedule(Long userId, ScheduleRequest request) {
-        // 복용 날짜와 알림 시각 검증
-        if (request.getAlarmAt() != null && !request.getDate().equals(request.getAlarmAt().toLocalDate())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "복용 날짜와 알림 시각의 날짜가 일치해야 합니다");
-        }
-        
         DrugDetailResponse drugDetail = fetchDrugDetailOrThrow(request.getDrugId());
         String resolvedDrugName = resolveDrugName(request, drugDetail);
         boolean alarmEnabled = resolveAlarmEnabled(request);
         
         // 등록 시에는 항상 SCHEDULED로 저장 (기본값)
         ScheduleStatus resolvedStatus = ScheduleStatus.SCHEDULED;
-
-        // 복용 기간 검증 (startDate, endDate가 있으면)
-        if (request.getStartDate() != null && request.getEndDate() != null) {
-            if (request.getStartDate().isAfter(request.getEndDate())) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "복용 시작일은 종료일보다 이전이어야 합니다");
-            }
-            // date가 기간 내에 있는지 검증 (선택사항)
-            if (request.getDate().isBefore(request.getStartDate()) || request.getDate().isAfter(request.getEndDate())) {
-                // 경고만 하고 계속 진행 (date가 기간 밖에 있어도 허용)
-            }
-        }
         
-        // 일정 생성 (단일 날짜, 복용 기간은 표시용)
+        // date와 time을 합쳐서 LocalDateTime 생성
+        LocalDateTime scheduleDateTime = request.getDate().atTime(request.getTime());
+        
+        // alarmAt을 복용 시각에서 30분 전으로 자동 계산
+        LocalDateTime alarmAt = scheduleDateTime.minus(30, ChronoUnit.MINUTES);
+        
+        // 일정 생성 (단일 날짜만 사용, 복용 기간 제거)
         Schedule schedule = Schedule.builder()
                 .userId(userId)
                 .drugId(request.getDrugId())
                 .drugName(resolvedDrugName)
                 .dose(request.getDose())
-                .date(request.getDate())
-                .alarmAt(request.getAlarmAt())
-                .startDate(request.getStartDate())
-                .endDate(request.getEndDate())
+                .date(scheduleDateTime)
+                .alarmAt(alarmAt)
+                .startDate(null)  // 복용 기간 제거
+                .endDate(null)    // 복용 기간 제거
                 .memo(request.getMemo())
                 .alarmEnabled(alarmEnabled)
                 .repeatRule(null)
@@ -92,10 +84,10 @@ public class ScheduleService {
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 일정입니다"));
         
-        LocalDate today = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
         
         // 날짜가 지난 SCHEDULED 일정을 자동으로 MISSED로 변경
-        if (schedule.getDate().isBefore(today) && schedule.getStatus() == ScheduleStatus.SCHEDULED) {
+        if (schedule.getDate().isBefore(now) && schedule.getStatus() == ScheduleStatus.SCHEDULED) {
             schedule.updateStatus(ScheduleStatus.MISSED);
             scheduleRepository.save(schedule);
         }
@@ -112,11 +104,12 @@ public class ScheduleService {
     @Transactional(readOnly = false)
     public List<ScheduleResponse> getSchedulesByDate(Long userId, LocalDate date) {
         List<Schedule> schedules = scheduleRepository.findByUserIdAndDate(userId, date);
-        LocalDate today = LocalDate.now();
+        
+        LocalDateTime now = LocalDateTime.now();
         
         // 날짜가 지난 SCHEDULED 일정을 자동으로 MISSED로 변경
         schedules.forEach(schedule -> {
-            if (schedule.getDate().isBefore(today) && schedule.getStatus() == ScheduleStatus.SCHEDULED) {
+            if (schedule.getDate().isBefore(now) && schedule.getStatus() == ScheduleStatus.SCHEDULED) {
                 schedule.updateStatus(ScheduleStatus.MISSED);
                 scheduleRepository.save(schedule);
             }
@@ -146,11 +139,11 @@ public class ScheduleService {
                 .filter(s -> s.getUserId().equals(userId))
                 .collect(Collectors.toList());
         
-        LocalDate today = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
         
         // 날짜가 지난 SCHEDULED 일정을 자동으로 MISSED로 변경
         userSchedules.forEach(schedule -> {
-            if (schedule.getDate().isBefore(today) && schedule.getStatus() == ScheduleStatus.SCHEDULED) {
+            if (schedule.getDate().isBefore(now) && schedule.getStatus() == ScheduleStatus.SCHEDULED) {
                 schedule.updateStatus(ScheduleStatus.MISSED);
                 scheduleRepository.save(schedule);
             }
@@ -221,36 +214,22 @@ public class ScheduleService {
             schedule.setDrugName(officialName);
         }
         
-        // 복용 날짜 수정
-        if (request.getDate() != null && !request.getDate().equals(schedule.getDate())) {
-            schedule.updateDate(request.getDate());
+        // 복용 날짜 및 시각 수정 (date 또는 time이 변경되면 alarmAt도 자동으로 30분 전으로 재계산)
+        LocalDate newDate = request.getDate() != null ? request.getDate() : schedule.getDate().toLocalDate();
+        LocalTime newTime = request.getTime() != null ? request.getTime() : schedule.getDate().toLocalTime();
+        LocalDateTime newScheduleDateTime = newDate.atTime(newTime);
+        
+        // 날짜 또는 시간이 변경되었는지 확인
+        if (!newScheduleDateTime.equals(schedule.getDate())) {
+            schedule.updateDate(newScheduleDateTime);
+            // alarmAt을 복용 시각에서 30분 전으로 자동 계산
+            LocalDateTime newAlarmAt = newScheduleDateTime.minus(30, ChronoUnit.MINUTES);
+            schedule.updateAlarmAt(newAlarmAt);
         }
         
-        // 복용 예정 시각 수정
-        if (request.getAlarmAt() != null && !request.getAlarmAt().equals(schedule.getAlarmAt())) {
-            // 날짜와 알림 시각의 날짜가 일치하는지 검증
-            LocalDate scheduleDate = request.getDate() != null ? request.getDate() : schedule.getDate();
-            if (!scheduleDate.equals(request.getAlarmAt().toLocalDate())) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "복용 날짜와 알림 시각의 날짜가 일치해야 합니다");
-            }
-            schedule.updateAlarmAt(request.getAlarmAt());
-        }
-        
-        // 복용 기간 수정 (표시용)
-        if (request.getStartDate() != null && !request.getStartDate().equals(schedule.getStartDate())) {
-            schedule.updateStartDate(request.getStartDate());
-        }
-        
-        if (request.getEndDate() != null && !request.getEndDate().equals(schedule.getEndDate())) {
-            schedule.updateEndDate(request.getEndDate());
-        }
-        
-        // 복용 기간 검증 (startDate, endDate가 모두 있으면)
-        if (request.getStartDate() != null && request.getEndDate() != null) {
-            if (request.getStartDate().isAfter(request.getEndDate())) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "복용 시작일은 종료일보다 이전이어야 합니다");
-            }
-        }
+        // 복용 기간 제거 (null로 설정)
+        schedule.updateStartDate(null);
+        schedule.updateEndDate(null);
         
         // 복용량 수정
         if (request.getDose() != null && !request.getDose().equals(schedule.getDose())) {
@@ -313,7 +292,8 @@ public class ScheduleService {
                 }
                 
                 // 금지 타이머 계산 (카페인, 알코올)
-                List<BanTimerResponse> banTimers = medicationIntakeService.calculateBanTimersInternal(takenAt, schedule.getDrugId());
+                // 해당 날짜의 모든 SCHEDULED 일정 중 가장 높은 회피계수 사용
+                List<BanTimerResponse> banTimers = medicationIntakeService.calculateBanTimersInternal(schedule.getUserId(), takenAt);
                 
                 // 카페인과 알코올 타이머 분리
                 for (BanTimerResponse timer : banTimers) {
@@ -328,12 +308,12 @@ public class ScheduleService {
             // 사용자가 status를 명시적으로 변경하지 않은 경우
             // 날짜가 지났고 SCHEDULED 상태이면 자동으로 MISSED로 변경
             // 단, plan이 CANCELLED로 설정된 경우는 제외
-            LocalDate finalScheduleDate = request.getDate() != null ? request.getDate() : schedule.getDate();
-            LocalDate today = LocalDate.now();
+            LocalDateTime now = LocalDateTime.now();
             
-            // 날짜가 오늘보다 과거이고, 현재 상태가 SCHEDULED이면 MISSED로 자동 변경
+            // 날짜가 현재보다 과거이고, 현재 상태가 SCHEDULED이면 MISSED로 자동 변경
             // CANCELLED 상태는 자동 변경하지 않음
-            if (finalScheduleDate.isBefore(today) && schedule.getStatus() == ScheduleStatus.SCHEDULED) {
+            // newScheduleDateTime은 위에서 이미 계산됨
+            if (newScheduleDateTime.isBefore(now) && schedule.getStatus() == ScheduleStatus.SCHEDULED) {
                 schedule.updateStatus(ScheduleStatus.MISSED);
             }
         }
@@ -439,10 +419,8 @@ public class ScheduleService {
                 .drugId(schedule.getDrugId())
                 .name(schedule.getDrugName())
                 .dose(schedule.getDose())
-                .date(schedule.getDate())
-                .alarmAt(schedule.getAlarmAt())
-                .startDate(schedule.getStartDate())
-                .endDate(schedule.getEndDate())
+                .date(schedule.getDate().toLocalDate())
+                .time(schedule.getDate().toLocalTime())
                 .memo(schedule.getMemo())
                 .plan(resolvedPlan)
                 .status(resolvedStatus)


### PR DESCRIPTION
- 금지 타이머 계산 시 해당 날짜의 모든 SCHEDULED 일정 중 가장 높은 회피계수 적용
- 잔존 타이머와 동일한 로직으로 일관성 유지
- MedicationIntakeService에 findMaxAdjustmentFactor 메서드 추가
- 스케줄 관련 DTO 및 서비스 로직 개선

## 📌 변경 사항

- 주요 기능/버그 수정 요약

## 🔍 상세 내용

- 핵심 로직 설명 및 리뷰 시 참고 사항

## ✅ 체크리스트

- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항

- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)

- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
